### PR TITLE
Update ask sdk model

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/url-join": "^0.8.2",
     "@types/uuid": "^3.4.3",
     "actions-on-google": "2",
-    "ask-sdk-model": "1.4.0-beta.1",
+    "ask-sdk-model": "1.8.0",
     "azure-functions-ts-essentials": "^1.3.2",
     "bluebird": "^3.5.1",
     "botbuilder": "^3.13.1",

--- a/src/VoxaEvent.ts
+++ b/src/VoxaEvent.ts
@@ -79,7 +79,7 @@ export abstract class VoxaEvent implements IVoxaEvent {
   constructor(
     rawEvent: any,
     logOptions: LambdaLogOptions = {},
-    public executionContext?: AWSLambdaContext | AzureContext,
+    public executionContext?: AWSLambdaContext | AzureContext
   ) {
     this.rawEvent = _.cloneDeep(rawEvent);
     this.initSession();
@@ -111,7 +111,7 @@ export abstract class VoxaEvent implements IVoxaEvent {
 
     this.intent = {
       name: intentName,
-      params: {},
+      params: {}
     };
 
     this.request.type = "IntentRequest";

--- a/src/VoxaEvent.ts
+++ b/src/VoxaEvent.ts
@@ -79,7 +79,7 @@ export abstract class VoxaEvent implements IVoxaEvent {
   constructor(
     rawEvent: any,
     logOptions: LambdaLogOptions = {},
-    public executionContext?: AWSLambdaContext | AzureContext
+    public executionContext?: AWSLambdaContext | AzureContext,
   ) {
     this.rawEvent = _.cloneDeep(rawEvent);
     this.initSession();
@@ -111,7 +111,7 @@ export abstract class VoxaEvent implements IVoxaEvent {
 
     this.intent = {
       name: intentName,
-      params: {}
+      params: {},
     };
 
     this.request.type = "IntentRequest";

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export { VoxaPlatform } from "./platforms";
 export { IVoxaEvent, IVoxaIntentEvent, IVoxaIntent } from "./VoxaEvent";
 export { IVoxaReply } from "./VoxaReply";
 export {
+  AlexaCanFullfillReply,
   AlexaReply,
   AlexaPlatform,
   AccountLinkingCard as AlexaAccountLinkingCard,

--- a/src/platforms/alexa/AlexaCanFullfillReply.ts
+++ b/src/platforms/alexa/AlexaCanFullfillReply.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2018 Rain Agency <contact@rain.agency>
+ * Author: Rain Agency <contact@rain.agency>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { ResponseEnvelope } from "ask-sdk-model";
+import * as _ from "lodash";
+import { IBag, IVoxaEvent } from "../../VoxaEvent";
+import { IVoxaReply } from "../../VoxaReply";
+
+export class AlexaCanFullfillReply implements IVoxaReply, ResponseEnvelope {
+  public version = "1.0";
+  public response: any = {};
+  public sessionAttributes: IBag = {};
+
+  get hasMessages() {
+    return false;
+  }
+
+  get hasDirectives() {
+    return false;
+  }
+
+  get hasTerminated() {
+    return true;
+  }
+
+  public async saveSession(attributes: IBag, event: IVoxaEvent): Promise<void> {
+    this.sessionAttributes = attributes;
+  }
+
+  public terminate() {
+    if (!this.response) {
+      this.response = {};
+    }
+  }
+
+  public get speech(): string {
+    return _.get(this.response, "outputSpeech.ssml", "");
+  }
+
+  public get reprompt(): string {
+    return _.get(this.response, "reprompt.outputSpeech.ssml", "");
+  }
+
+  public addStatement(statement: string, isPlain: boolean = false) {
+    return;
+  }
+
+  public addReprompt(statement: string, isPlain: boolean = false) {
+    return;
+  }
+
+  public fulfillIntent(canFulfill: any) {
+    _.set(this.response, "card", undefined);
+    _.set(this.response, "reprompt", undefined);
+    _.set(this.response, "outputSpeech", undefined);
+
+    if (!_.includes(["YES", "NO", "MAYBE"], canFulfill)) {
+      this.response.canFulfillIntent = { canFulfill: "NO" };
+    } else {
+      this.response.canFulfillIntent = { canFulfill };
+    }
+  }
+
+  public fulfillSlot(slotName: string, canUnderstand: any, canFulfill: any) {
+    if (!_.includes(["YES", "NO", "MAYBE"], canUnderstand)) {
+      canUnderstand = "NO";
+    }
+
+    if (!_.includes(["YES", "NO"], canFulfill)) {
+      canFulfill = "NO";
+    }
+
+    this.response.canFulfillIntent = this.response.canFulfillIntent || {
+      canFulfill: "NO",
+    };
+    this.response.canFulfillIntent.slots =
+      this.response.canFulfillIntent.slots || {};
+
+    this.response.canFulfillIntent.slots[slotName] = {
+      canFulfill,
+      canUnderstand,
+    };
+  }
+
+  public clear() {
+    this.response = {};
+  }
+
+  public hasDirective(type: string | RegExp): boolean {
+    return false;
+  }
+}

--- a/src/platforms/alexa/AlexaEvent.ts
+++ b/src/platforms/alexa/AlexaEvent.ts
@@ -23,7 +23,7 @@
 import {
   IntentRequest,
   RequestEnvelope,
-  User as IAlexaUser
+  User as IAlexaUser,
 } from "ask-sdk-model";
 import { Context as AWSLambdaContext } from "aws-lambda";
 import { Context as AzureContext } from "azure-functions-ts-essentials";
@@ -36,7 +36,7 @@ import {
   DeviceAddress,
   DeviceSettings,
   InSkillPurchase,
-  Lists
+  Lists,
 } from "./apis";
 
 export class AlexaEvent extends VoxaEvent {
@@ -54,19 +54,19 @@ export class AlexaEvent extends VoxaEvent {
     "Connections.Response": "Connections.Response",
     "Display.ElementSelected": "Display.ElementSelected",
     "GameEngine.InputHandlerEvent": "GameEngine.InputHandlerEvent",
-    LaunchRequest: "LaunchIntent"
+    "LaunchRequest": "LaunchIntent",
   };
 
   constructor(
     rawEvent: RequestEnvelope,
     logOptions?: LambdaLogOptions,
-    executionContext?: AWSLambdaContext | AzureContext
+    executionContext?: AWSLambdaContext | AzureContext,
   ) {
     super(rawEvent, logOptions, executionContext);
 
     this.request = {
       locale: _.get(rawEvent, "request.locale"),
-      type: rawEvent.request.type
+      type: rawEvent.request.type,
     };
 
     this.initIntents();
@@ -87,7 +87,7 @@ export class AlexaEvent extends VoxaEvent {
     this.user = {
       accessToken: user.accessToken,
       id: user.userId,
-      userId: user.userId
+      userId: user.userId,
     };
   }
 
@@ -99,7 +99,7 @@ export class AlexaEvent extends VoxaEvent {
     const interfaces = _.get(
       this.rawEvent,
       "context.System.device.supportedInterfaces",
-      {}
+      {},
     );
     return _.keys(interfaces);
   }
@@ -110,7 +110,7 @@ export class AlexaEvent extends VoxaEvent {
       deviceAddress: new DeviceAddress(this.rawEvent, this.log),
       deviceSettings: new DeviceSettings(this.rawEvent, this.log),
       isp: new InSkillPurchase(this.rawEvent, this.log),
-      lists: new Lists(this.rawEvent, this.log)
+      lists: new Lists(this.rawEvent, this.log),
     };
   }
 
@@ -119,7 +119,7 @@ export class AlexaEvent extends VoxaEvent {
       attributes: _.get(this.rawEvent, "session.attributes", {}),
       new: _.get(this.rawEvent, "session.new", false),
       outputAttributes: {},
-      sessionId: _.get(this.rawEvent, "session.sessionId", "")
+      sessionId: _.get(this.rawEvent, "session.sessionId", ""),
     };
   }
 

--- a/src/platforms/alexa/AlexaEvent.ts
+++ b/src/platforms/alexa/AlexaEvent.ts
@@ -21,7 +21,6 @@
  */
 
 import {
-  canfulfill,
   IntentRequest,
   RequestEnvelope,
   User as IAlexaUser,
@@ -66,7 +65,7 @@ export class AlexaEvent extends VoxaEvent {
     super(rawEvent, logOptions, executionContext);
 
     this.request = {
-      locale: rawEvent.request.locale,
+      locale: _.get(rawEvent, 'request.locale'),
       type: rawEvent.request.type,
     };
 
@@ -134,7 +133,7 @@ export class AlexaEvent extends VoxaEvent {
 
 function isIntentRequest(
   request: any,
-): request is IntentRequest | canfulfill.CanFulfillIntentRequest {
+): request is IntentRequest {
   return (
     request.type === "IntentRequest" ||
     request.type === "CanFulfillIntentRequest"

--- a/src/platforms/alexa/AlexaEvent.ts
+++ b/src/platforms/alexa/AlexaEvent.ts
@@ -23,7 +23,7 @@
 import {
   IntentRequest,
   RequestEnvelope,
-  User as IAlexaUser,
+  User as IAlexaUser
 } from "ask-sdk-model";
 import { Context as AWSLambdaContext } from "aws-lambda";
 import { Context as AzureContext } from "azure-functions-ts-essentials";
@@ -36,7 +36,7 @@ import {
   DeviceAddress,
   DeviceSettings,
   InSkillPurchase,
-  Lists,
+  Lists
 } from "./apis";
 
 export class AlexaEvent extends VoxaEvent {
@@ -54,19 +54,19 @@ export class AlexaEvent extends VoxaEvent {
     "Connections.Response": "Connections.Response",
     "Display.ElementSelected": "Display.ElementSelected",
     "GameEngine.InputHandlerEvent": "GameEngine.InputHandlerEvent",
-    "LaunchRequest": "LaunchIntent",
+    LaunchRequest: "LaunchIntent"
   };
 
   constructor(
     rawEvent: RequestEnvelope,
     logOptions?: LambdaLogOptions,
-    executionContext?: AWSLambdaContext | AzureContext,
+    executionContext?: AWSLambdaContext | AzureContext
   ) {
     super(rawEvent, logOptions, executionContext);
 
     this.request = {
-      locale: _.get(rawEvent, 'request.locale'),
-      type: rawEvent.request.type,
+      locale: _.get(rawEvent, "request.locale"),
+      type: rawEvent.request.type
     };
 
     this.initIntents();
@@ -87,7 +87,7 @@ export class AlexaEvent extends VoxaEvent {
     this.user = {
       accessToken: user.accessToken,
       id: user.userId,
-      userId: user.userId,
+      userId: user.userId
     };
   }
 
@@ -99,7 +99,7 @@ export class AlexaEvent extends VoxaEvent {
     const interfaces = _.get(
       this.rawEvent,
       "context.System.device.supportedInterfaces",
-      {},
+      {}
     );
     return _.keys(interfaces);
   }
@@ -110,7 +110,7 @@ export class AlexaEvent extends VoxaEvent {
       deviceAddress: new DeviceAddress(this.rawEvent, this.log),
       deviceSettings: new DeviceSettings(this.rawEvent, this.log),
       isp: new InSkillPurchase(this.rawEvent, this.log),
-      lists: new Lists(this.rawEvent, this.log),
+      lists: new Lists(this.rawEvent, this.log)
     };
   }
 
@@ -119,7 +119,7 @@ export class AlexaEvent extends VoxaEvent {
       attributes: _.get(this.rawEvent, "session.attributes", {}),
       new: _.get(this.rawEvent, "session.new", false),
       outputAttributes: {},
-      sessionId: _.get(this.rawEvent, "session.sessionId", ""),
+      sessionId: _.get(this.rawEvent, "session.sessionId", "")
     };
   }
 
@@ -131,9 +131,7 @@ export class AlexaEvent extends VoxaEvent {
   }
 }
 
-function isIntentRequest(
-  request: any,
-): request is IntentRequest {
+function isIntentRequest(request: any): request is IntentRequest {
   return (
     request.type === "IntentRequest" ||
     request.type === "CanFulfillIntentRequest"

--- a/src/platforms/alexa/AlexaPlatform.ts
+++ b/src/platforms/alexa/AlexaPlatform.ts
@@ -29,6 +29,7 @@ import { VoxaApp } from "../../VoxaApp";
 import { IVoxaEvent, IVoxaIntentEvent } from "../../VoxaEvent";
 import { IVoxaReply } from "../../VoxaReply";
 import { IVoxaPlatformConfig, VoxaPlatform } from "../VoxaPlatform";
+import { AlexaCanFullfillReply } from "./AlexaCanFullfillReply";
 import { AlexaEvent } from "./AlexaEvent";
 import { AlexaReply } from "./AlexaReply";
 import {
@@ -86,7 +87,7 @@ export class AlexaPlatform extends VoxaPlatform {
     this.config = config;
 
     this.app.onCanFulfillIntentRequest(
-      (event: IVoxaIntentEvent, reply: AlexaReply) => {
+      (event: IVoxaIntentEvent, reply: AlexaCanFullfillReply) => {
         if (_.includes(this.config.defaultFulfillIntents, event.intent.name)) {
           reply.fulfillIntent("YES");
 
@@ -137,7 +138,11 @@ export class AlexaPlatform extends VoxaPlatform {
   }
 
   protected getReply(event: IVoxaEvent): IVoxaReply {
-    return new AlexaReply(event);
+    if (event.request.type === "CanFulfillIntentRequest") {
+      return new AlexaCanFullfillReply();
+    }
+
+    return new AlexaReply();
   }
 
   protected checkSessionEndedRequest(alexaEvent: AlexaEvent): void {

--- a/src/platforms/alexa/AlexaPlatform.ts
+++ b/src/platforms/alexa/AlexaPlatform.ts
@@ -42,7 +42,7 @@ import {
   HomeCard,
   PlayAudio,
   RenderTemplate,
-  StopAudio,
+  StopAudio
 } from "./directives";
 
 const AlexaRequests = [
@@ -67,7 +67,7 @@ const AlexaRequests = [
   "Connections.Response",
   "Display.ElementSelected",
   "CanFulfillIntentRequest",
-  "GameEngine.InputHandlerEvent",
+  "GameEngine.InputHandlerEvent"
 ];
 
 export interface IAlexaPlatformConfig extends IVoxaPlatformConfig {
@@ -96,7 +96,7 @@ export class AlexaPlatform extends VoxaPlatform {
         }
 
         return reply;
-      },
+      }
     );
   }
 
@@ -112,7 +112,7 @@ export class AlexaPlatform extends VoxaPlatform {
       HomeCard,
       PlayAudio,
       RenderTemplate,
-      StopAudio,
+      StopAudio
     ];
   }
 
@@ -122,7 +122,7 @@ export class AlexaPlatform extends VoxaPlatform {
 
   public async execute(
     rawEvent: RequestEnvelope,
-    context?: AWSLambdaContext | AzureContext,
+    context?: AWSLambdaContext | AzureContext
   ): Promise<any> {
     this.checkAppIds(rawEvent);
     const alexaEvent = (await this.getEvent(rawEvent, context)) as AlexaEvent;

--- a/src/platforms/alexa/AlexaPlatform.ts
+++ b/src/platforms/alexa/AlexaPlatform.ts
@@ -137,7 +137,7 @@ export class AlexaPlatform extends VoxaPlatform {
   }
 
   protected getReply(event: IVoxaEvent): IVoxaReply {
-    return new AlexaReply();
+    return new AlexaReply(event);
   }
 
   protected checkSessionEndedRequest(alexaEvent: AlexaEvent): void {

--- a/src/platforms/alexa/AlexaPlatform.ts
+++ b/src/platforms/alexa/AlexaPlatform.ts
@@ -42,7 +42,7 @@ import {
   HomeCard,
   PlayAudio,
   RenderTemplate,
-  StopAudio
+  StopAudio,
 } from "./directives";
 
 const AlexaRequests = [
@@ -67,7 +67,7 @@ const AlexaRequests = [
   "Connections.Response",
   "Display.ElementSelected",
   "CanFulfillIntentRequest",
-  "GameEngine.InputHandlerEvent"
+  "GameEngine.InputHandlerEvent",
 ];
 
 export interface IAlexaPlatformConfig extends IVoxaPlatformConfig {
@@ -96,7 +96,7 @@ export class AlexaPlatform extends VoxaPlatform {
         }
 
         return reply;
-      }
+      },
     );
   }
 
@@ -112,7 +112,7 @@ export class AlexaPlatform extends VoxaPlatform {
       HomeCard,
       PlayAudio,
       RenderTemplate,
-      StopAudio
+      StopAudio,
     ];
   }
 
@@ -122,7 +122,7 @@ export class AlexaPlatform extends VoxaPlatform {
 
   public async execute(
     rawEvent: RequestEnvelope,
-    context?: AWSLambdaContext | AzureContext
+    context?: AWSLambdaContext | AzureContext,
   ): Promise<any> {
     this.checkAppIds(rawEvent);
     const alexaEvent = (await this.getEvent(rawEvent, context)) as AlexaEvent;

--- a/src/platforms/alexa/AlexaReply.ts
+++ b/src/platforms/alexa/AlexaReply.ts
@@ -24,16 +24,16 @@ import { Response, ResponseEnvelope } from "ask-sdk-model";
 import * as _ from "lodash";
 import { IBag, IVoxaEvent } from "../../VoxaEvent";
 import { addToSSML, IVoxaReply } from "../../VoxaReply";
-import { canfulfill } from "./CanFullfillintent";
+import * as canfulfill from "./CanFullfillintent";
 
 function isCanFullfillIntentResponse(
-  response: any
+  response: any,
 ): response is canfulfill.CanFulfillResponse {
   return !_.isUndefined(response.canFulfillIntent);
 }
 
 function isCanFullfillIntentRequest(
-  request: any
+  request: any,
 ): request is canfulfill.CanFulfillIntentRequest {
   if (_.isUndefined(request)) {
     return false;
@@ -121,12 +121,12 @@ export class AlexaReply implements IVoxaReply, ResponseEnvelope {
     let ssml: string = _.get(
       this.response,
       "outputSpeech.ssml",
-      "<speak></speak>"
+      "<speak></speak>",
     );
     ssml = addToSSML(ssml, statement);
     this.response.outputSpeech = {
       ssml,
-      type: "SSML"
+      type: "SSML",
     };
   }
 
@@ -139,14 +139,14 @@ export class AlexaReply implements IVoxaReply, ResponseEnvelope {
     let ssml: string = _.get(
       this.response.reprompt,
       "outputSpeech.ssml",
-      "<speak></speak>"
+      "<speak></speak>",
     );
     ssml = addToSSML(ssml, statement);
     this.response.reprompt = {
       outputSpeech: {
         ssml,
-        type
-      }
+        type,
+      },
     };
   }
 
@@ -180,14 +180,14 @@ export class AlexaReply implements IVoxaReply, ResponseEnvelope {
     }
 
     this.response.canFulfillIntent = this.response.canFulfillIntent || {
-      canFulfill: "NO"
+      canFulfill: "NO",
     };
     this.response.canFulfillIntent.slots =
       this.response.canFulfillIntent.slots || {};
 
     this.response.canFulfillIntent.slots[slotName] = {
       canFulfill,
-      canUnderstand
+      canUnderstand,
     };
   }
 
@@ -208,7 +208,7 @@ export class AlexaReply implements IVoxaReply, ResponseEnvelope {
     if (this.response.card) {
       allDirectives = _.concat(allDirectives, {
         card: this.response.card,
-        type: "card"
+        type: "card",
       });
     }
 
@@ -222,7 +222,7 @@ export class AlexaReply implements IVoxaReply, ResponseEnvelope {
       }
 
       throw new Error(
-        `Do not know how to use a ${typeof type} to find a directive`
+        `Do not know how to use a ${typeof type} to find a directive`,
       );
     });
   }

--- a/src/platforms/alexa/AlexaReply.ts
+++ b/src/platforms/alexa/AlexaReply.ts
@@ -24,26 +24,22 @@ import { Response, ResponseEnvelope } from "ask-sdk-model";
 import * as _ from "lodash";
 import { IBag, IVoxaEvent } from "../../VoxaEvent";
 import { addToSSML, IVoxaReply } from "../../VoxaReply";
-import { canfulfill } from './CanFullfillintent';
+import { canfulfill } from "./CanFullfillintent";
 
 function isCanFullfillIntentResponse(
-  response: any,
+  response: any
 ): response is canfulfill.CanFulfillResponse {
-  return (
-    !_.isUndefined(response.canFulfillIntent)
-  );
+  return !_.isUndefined(response.canFulfillIntent);
 }
 
 function isCanFullfillIntentRequest(
-  request: any,
+  request: any
 ): request is canfulfill.CanFulfillIntentRequest {
   if (_.isUndefined(request)) {
     return false;
   }
 
-  return (
-    request.request.type === "CanFulfillIntentRequest"
-  );
+  return request.request.type === "CanFulfillIntentRequest";
 }
 
 export class AlexaReply implements IVoxaReply, ResponseEnvelope {
@@ -125,12 +121,12 @@ export class AlexaReply implements IVoxaReply, ResponseEnvelope {
     let ssml: string = _.get(
       this.response,
       "outputSpeech.ssml",
-      "<speak></speak>",
+      "<speak></speak>"
     );
     ssml = addToSSML(ssml, statement);
     this.response.outputSpeech = {
       ssml,
-      type: "SSML",
+      type: "SSML"
     };
   }
 
@@ -143,14 +139,14 @@ export class AlexaReply implements IVoxaReply, ResponseEnvelope {
     let ssml: string = _.get(
       this.response.reprompt,
       "outputSpeech.ssml",
-      "<speak></speak>",
+      "<speak></speak>"
     );
     ssml = addToSSML(ssml, statement);
     this.response.reprompt = {
       outputSpeech: {
         ssml,
-        type,
-      },
+        type
+      }
     };
   }
 
@@ -159,9 +155,9 @@ export class AlexaReply implements IVoxaReply, ResponseEnvelope {
       return;
     }
 
-    _.set(this.response, 'card', undefined);
-    _.set(this.response, 'reprompt', undefined);
-    _.set(this.response, 'outputSpeech', undefined);
+    _.set(this.response, "card", undefined);
+    _.set(this.response, "reprompt", undefined);
+    _.set(this.response, "outputSpeech", undefined);
 
     if (!_.includes(["YES", "NO", "MAYBE"], canFulfill)) {
       this.response.canFulfillIntent = { canFulfill: "NO" };
@@ -184,14 +180,14 @@ export class AlexaReply implements IVoxaReply, ResponseEnvelope {
     }
 
     this.response.canFulfillIntent = this.response.canFulfillIntent || {
-      canFulfill: "NO",
+      canFulfill: "NO"
     };
     this.response.canFulfillIntent.slots =
       this.response.canFulfillIntent.slots || {};
 
     this.response.canFulfillIntent.slots[slotName] = {
       canFulfill,
-      canUnderstand,
+      canUnderstand
     };
   }
 
@@ -212,7 +208,7 @@ export class AlexaReply implements IVoxaReply, ResponseEnvelope {
     if (this.response.card) {
       allDirectives = _.concat(allDirectives, {
         card: this.response.card,
-        type: "card",
+        type: "card"
       });
     }
 
@@ -226,7 +222,7 @@ export class AlexaReply implements IVoxaReply, ResponseEnvelope {
       }
 
       throw new Error(
-        `Do not know how to use a ${typeof type} to find a directive`,
+        `Do not know how to use a ${typeof type} to find a directive`
       );
     });
   }

--- a/src/platforms/alexa/CanFullfillintent.ts
+++ b/src/platforms/alexa/CanFullfillintent.ts
@@ -1,67 +1,60 @@
 import { DialogState, Intent } from "ask-sdk-model";
 
-export declare namespace canfulfill {
-  /**
-   * An object that represents a request made to skill to query whether the skill can understand and fulfill the intent request with detected slots, before actually asking the skill to take action. Skill should be aware this is not to actually take action, skill should handle this request without causing side-effect, skill should not modify some state outside its scope or has an observable interaction with its calling functions or the outside world besides returning a value, such as playing sound,turning on/off lights, committing a transaction or a charge.
-   * @interface
-   */
-  interface CanFulfillIntentRequest {
-    type: "CanFulfillIntentRequest";
-    requestId: string;
-    timestamp: string;
-    locale: string;
-    dialogState?: DialogState;
-    intent: Intent;
-  }
+/**
+ * An object that represents a request made to skill to query whether the skill can understand and fulfill the intent request with detected slots, before actually asking the skill to take action. Skill should be aware this is not to actually take action, skill should handle this request without causing side-effect, skill should not modify some state outside its scope or has an observable interaction with its calling functions or the outside world besides returning a value, such as playing sound,turning on/off lights, committing a transaction or a charge.
+ * @interface
+ */
+// tslint:disable-next-line
+export interface CanFulfillIntentRequest {
+  type: "CanFulfillIntentRequest";
+  requestId: string;
+  timestamp: string;
+  locale: string;
+  dialogState?: DialogState;
+  intent: Intent;
 }
 
-export declare namespace canfulfill {
-  /**
-   * Overall if skill can understand and fulfill the intent with detected slots. Respond YES when skill understands all slots, can fulfill all slots, and can fulfill the request in its entirety. Respond NO when skill either cannot understand the intent, cannot understand all the slots, or cannot fulfill all the slots. Respond MAYBE when skill can understand the intent, can partially or fully understand the slots, and can partially or fully fulfill the slots. The only cases where should respond MAYBE is when skill partially understand the request and can potentially complete the request if skill get more data, either through callbacks or through a multi-turn conversation with the user.
-   * @enum
-   */
-  type CanFulfillIntentValues = "YES" | "NO" | "MAYBE";
-}
-export declare namespace canfulfill {
-  /**
-   * This represents skill's capability to understand and fulfill each detected slot.
-   * @interface
-   */
-  interface CanFulfillSlot {
-    canUnderstand: canfulfill.CanUnderstandSlotValues;
-    canFulfill?: canfulfill.CanFulfillSlotValues;
-  }
-}
-export declare namespace canfulfill {
-  /**
-   * This field indicates whether skill can fulfill relevant action for the slot, that has been partially or fully understood. The definition of fulfilling the slot is dependent on skill and skill is required to have logic in place to determine whether a slot value can be fulfilled in the context of skill or not. Return YES if Skill can certainly fulfill the relevant action for this slot value. Return NO if skill cannot fulfill the relevant action for this slot value. For specific recommendations to set the value refer to the developer docs for more details.
-   * @enum
-   */
-  type CanFulfillSlotValues = "YES" | "NO";
-}
-export declare namespace canfulfill {
-  /**
-   * This field indicates whether skill has understood the slot value. In most typical cases, skills will do some form of entity resolution by looking up a catalog or list to determine whether they recognize the slot or not. Return YES if skill have a perfect match or high confidence match (for eg. synonyms) with catalog or list maintained by skill. Return NO if skill cannot understand or recognize the slot value. Return MAYBE if skill have partial confidence or partial match. This will be true when the slot value doesn’t exist as is, in the catalog, but a variation or a fuzzy match may exist. For specific recommendations to set the value refer to the developer docs for more details.
-   * @enum
-   */
-  type CanUnderstandSlotValues = "YES" | "NO" | "MAYBE";
+/**
+ * Overall if skill can understand and fulfill the intent with detected slots. Respond YES when skill understands all slots, can fulfill all slots, and can fulfill the request in its entirety. Respond NO when skill either cannot understand the intent, cannot understand all the slots, or cannot fulfill all the slots. Respond MAYBE when skill can understand the intent, can partially or fully understand the slots, and can partially or fully fulfill the slots. The only cases where should respond MAYBE is when skill partially understand the request and can potentially complete the request if skill get more data, either through callbacks or through a multi-turn conversation with the user.
+ * @enum
+ */
+type CanFulfillIntentValues = "YES" | "NO" | "MAYBE";
+
+/**
+ * This represents skill's capability to understand and fulfill each detected slot.
+ * @interface
+ */
+// tslint:disable-next-line
+export interface CanFulfillSlot {
+  canUnderstand: CanUnderstandSlotValues;
+  canFulfill?: CanFulfillSlotValues;
 }
 
-export declare namespace canfulfill {
-  /**
-   * CanFulfillIntent represents the response to canFulfillIntentRequest includes the details about whether the skill can understand and fulfill the intent request with detected slots.
-   * @interface
-   */
-  interface CanFulfillIntent {
-    canFulfill: canfulfill.CanFulfillIntentValues;
-    slots?: {
-      [key: string]: canfulfill.CanFulfillSlot;
-    };
-  }
+/**
+ * This field indicates whether skill can fulfill relevant action for the slot, that has been partially or fully understood. The definition of fulfilling the slot is dependent on skill and skill is required to have logic in place to determine whether a slot value can be fulfilled in the context of skill or not. Return YES if Skill can certainly fulfill the relevant action for this slot value. Return NO if skill cannot fulfill the relevant action for this slot value. For specific recommendations to set the value refer to the developer docs for more details.
+ * @enum
+ */
+type CanFulfillSlotValues = "YES" | "NO";
+
+/**
+ * This field indicates whether skill has understood the slot value. In most typical cases, skills will do some form of entity resolution by looking up a catalog or list to determine whether they recognize the slot or not. Return YES if skill have a perfect match or high confidence match (for eg. synonyms) with catalog or list maintained by skill. Return NO if skill cannot understand or recognize the slot value. Return MAYBE if skill have partial confidence or partial match. This will be true when the slot value doesn’t exist as is, in the catalog, but a variation or a fuzzy match may exist. For specific recommendations to set the value refer to the developer docs for more details.
+ * @enum
+ */
+type CanUnderstandSlotValues = "YES" | "NO" | "MAYBE";
+
+/**
+ * CanFulfillIntent represents the response to canFulfillIntentRequest includes the details about whether the skill can understand and fulfill the intent request with detected slots.
+ * @interface
+ */
+// tslint:disable-next-line
+export interface CanFulfillIntent {
+  canFulfill: CanFulfillIntentValues;
+  slots?: {
+    [key: string]: CanFulfillSlot;
+  };
 }
 
-export declare namespace canfulfill {
-  interface CanFulfillResponse {
-    canFulfillIntent: canfulfill.CanFulfillIntent;
-  }
+// tslint:disable-next-line
+export interface CanFulfillResponse {
+  canFulfillIntent: CanFulfillIntent;
 }

--- a/src/platforms/alexa/CanFullfillintent.ts
+++ b/src/platforms/alexa/CanFullfillintent.ts
@@ -1,4 +1,4 @@
-import { DialogState, Intent } from 'ask-sdk-model';
+import { DialogState, Intent } from "ask-sdk-model";
 
 export declare namespace canfulfill {
   /**
@@ -6,12 +6,12 @@ export declare namespace canfulfill {
    * @interface
    */
   interface CanFulfillIntentRequest {
-      'type': 'CanFulfillIntentRequest';
-      'requestId': string;
-      'timestamp': string;
-      'locale': string;
-      'dialogState'?: DialogState;
-      'intent': Intent;
+    type: "CanFulfillIntentRequest";
+    requestId: string;
+    timestamp: string;
+    locale: string;
+    dialogState?: DialogState;
+    intent: Intent;
   }
 }
 
@@ -20,7 +20,7 @@ export declare namespace canfulfill {
    * Overall if skill can understand and fulfill the intent with detected slots. Respond YES when skill understands all slots, can fulfill all slots, and can fulfill the request in its entirety. Respond NO when skill either cannot understand the intent, cannot understand all the slots, or cannot fulfill all the slots. Respond MAYBE when skill can understand the intent, can partially or fully understand the slots, and can partially or fully fulfill the slots. The only cases where should respond MAYBE is when skill partially understand the request and can potentially complete the request if skill get more data, either through callbacks or through a multi-turn conversation with the user.
    * @enum
    */
-  type CanFulfillIntentValues = 'YES' | 'NO' | 'MAYBE';
+  type CanFulfillIntentValues = "YES" | "NO" | "MAYBE";
 }
 export declare namespace canfulfill {
   /**
@@ -28,8 +28,8 @@ export declare namespace canfulfill {
    * @interface
    */
   interface CanFulfillSlot {
-      'canUnderstand': canfulfill.CanUnderstandSlotValues;
-      'canFulfill'?: canfulfill.CanFulfillSlotValues;
+    canUnderstand: canfulfill.CanUnderstandSlotValues;
+    canFulfill?: canfulfill.CanFulfillSlotValues;
   }
 }
 export declare namespace canfulfill {
@@ -37,14 +37,14 @@ export declare namespace canfulfill {
    * This field indicates whether skill can fulfill relevant action for the slot, that has been partially or fully understood. The definition of fulfilling the slot is dependent on skill and skill is required to have logic in place to determine whether a slot value can be fulfilled in the context of skill or not. Return YES if Skill can certainly fulfill the relevant action for this slot value. Return NO if skill cannot fulfill the relevant action for this slot value. For specific recommendations to set the value refer to the developer docs for more details.
    * @enum
    */
-  type CanFulfillSlotValues = 'YES' | 'NO';
+  type CanFulfillSlotValues = "YES" | "NO";
 }
 export declare namespace canfulfill {
   /**
    * This field indicates whether skill has understood the slot value. In most typical cases, skills will do some form of entity resolution by looking up a catalog or list to determine whether they recognize the slot or not. Return YES if skill have a perfect match or high confidence match (for eg. synonyms) with catalog or list maintained by skill. Return NO if skill cannot understand or recognize the slot value. Return MAYBE if skill have partial confidence or partial match. This will be true when the slot value doesn’t exist as is, in the catalog, but a variation or a fuzzy match may exist. For specific recommendations to set the value refer to the developer docs for more details.
    * @enum
    */
-  type CanUnderstandSlotValues = 'YES' | 'NO' | 'MAYBE';
+  type CanUnderstandSlotValues = "YES" | "NO" | "MAYBE";
 }
 
 export declare namespace canfulfill {
@@ -53,16 +53,15 @@ export declare namespace canfulfill {
    * @interface
    */
   interface CanFulfillIntent {
-      'canFulfill': canfulfill.CanFulfillIntentValues;
-      'slots'?: {
-          [key: string]: canfulfill.CanFulfillSlot;
-      };
+    canFulfill: canfulfill.CanFulfillIntentValues;
+    slots?: {
+      [key: string]: canfulfill.CanFulfillSlot;
+    };
   }
 }
 
 export declare namespace canfulfill {
-
   interface CanFulfillResponse {
-      'canFulfillIntent': canfulfill.CanFulfillIntent;
+    canFulfillIntent: canfulfill.CanFulfillIntent;
   }
 }

--- a/src/platforms/alexa/CanFullfillintent.ts
+++ b/src/platforms/alexa/CanFullfillintent.ts
@@ -1,0 +1,68 @@
+import { DialogState, Intent } from 'ask-sdk-model';
+
+export declare namespace canfulfill {
+  /**
+   * An object that represents a request made to skill to query whether the skill can understand and fulfill the intent request with detected slots, before actually asking the skill to take action. Skill should be aware this is not to actually take action, skill should handle this request without causing side-effect, skill should not modify some state outside its scope or has an observable interaction with its calling functions or the outside world besides returning a value, such as playing sound,turning on/off lights, committing a transaction or a charge.
+   * @interface
+   */
+  interface CanFulfillIntentRequest {
+      'type': 'CanFulfillIntentRequest';
+      'requestId': string;
+      'timestamp': string;
+      'locale': string;
+      'dialogState'?: DialogState;
+      'intent': Intent;
+  }
+}
+
+export declare namespace canfulfill {
+  /**
+   * Overall if skill can understand and fulfill the intent with detected slots. Respond YES when skill understands all slots, can fulfill all slots, and can fulfill the request in its entirety. Respond NO when skill either cannot understand the intent, cannot understand all the slots, or cannot fulfill all the slots. Respond MAYBE when skill can understand the intent, can partially or fully understand the slots, and can partially or fully fulfill the slots. The only cases where should respond MAYBE is when skill partially understand the request and can potentially complete the request if skill get more data, either through callbacks or through a multi-turn conversation with the user.
+   * @enum
+   */
+  type CanFulfillIntentValues = 'YES' | 'NO' | 'MAYBE';
+}
+export declare namespace canfulfill {
+  /**
+   * This represents skill's capability to understand and fulfill each detected slot.
+   * @interface
+   */
+  interface CanFulfillSlot {
+      'canUnderstand': canfulfill.CanUnderstandSlotValues;
+      'canFulfill'?: canfulfill.CanFulfillSlotValues;
+  }
+}
+export declare namespace canfulfill {
+  /**
+   * This field indicates whether skill can fulfill relevant action for the slot, that has been partially or fully understood. The definition of fulfilling the slot is dependent on skill and skill is required to have logic in place to determine whether a slot value can be fulfilled in the context of skill or not. Return YES if Skill can certainly fulfill the relevant action for this slot value. Return NO if skill cannot fulfill the relevant action for this slot value. For specific recommendations to set the value refer to the developer docs for more details.
+   * @enum
+   */
+  type CanFulfillSlotValues = 'YES' | 'NO';
+}
+export declare namespace canfulfill {
+  /**
+   * This field indicates whether skill has understood the slot value. In most typical cases, skills will do some form of entity resolution by looking up a catalog or list to determine whether they recognize the slot or not. Return YES if skill have a perfect match or high confidence match (for eg. synonyms) with catalog or list maintained by skill. Return NO if skill cannot understand or recognize the slot value. Return MAYBE if skill have partial confidence or partial match. This will be true when the slot value doesn’t exist as is, in the catalog, but a variation or a fuzzy match may exist. For specific recommendations to set the value refer to the developer docs for more details.
+   * @enum
+   */
+  type CanUnderstandSlotValues = 'YES' | 'NO' | 'MAYBE';
+}
+
+export declare namespace canfulfill {
+  /**
+   * CanFulfillIntent represents the response to canFulfillIntentRequest includes the details about whether the skill can understand and fulfill the intent request with detected slots.
+   * @interface
+   */
+  interface CanFulfillIntent {
+      'canFulfill': canfulfill.CanFulfillIntentValues;
+      'slots'?: {
+          [key: string]: canfulfill.CanFulfillSlot;
+      };
+  }
+}
+
+export declare namespace canfulfill {
+
+  interface CanFulfillResponse {
+      'canFulfillIntent': canfulfill.CanFulfillIntent;
+  }
+}

--- a/src/platforms/alexa/apis/InSkillPurchase.ts
+++ b/src/platforms/alexa/apis/InSkillPurchase.ts
@@ -40,7 +40,7 @@ export class InSkillPurchase {
 
   public static cancel(
     productId: string,
-    token: string
+    token: string,
   ): ConnectionsSendRequest {
     return this.sendConnectionSendRequest("Cancel", productId, token);
   }
@@ -48,13 +48,13 @@ export class InSkillPurchase {
   public static upsell(
     productId: string,
     upsellMessage: string,
-    token: string
+    token: string,
   ): ConnectionsSendRequest {
     return this.sendConnectionSendRequest(
       "Upsell",
       productId,
       token,
-      upsellMessage
+      upsellMessage,
     );
   }
 
@@ -62,7 +62,7 @@ export class InSkillPurchase {
     method: string,
     productId: string,
     token: string,
-    upsellMessage?: string
+    upsellMessage?: string,
   ): ConnectionsSendRequest {
     const payload = this.formatPayload(productId, upsellMessage);
     return new ConnectionsSendRequest(method, payload, token);
@@ -70,13 +70,13 @@ export class InSkillPurchase {
 
   protected static formatPayload(
     productId: string,
-    upsellMessage?: string
+    upsellMessage?: string,
   ): IPurchasePayload {
     return {
       InSkillProduct: {
-        productId
+        productId,
       },
-      upsellMessage
+      upsellMessage,
     };
   }
 
@@ -88,7 +88,7 @@ export class InSkillPurchase {
 
   public isAllowed() {
     const ALLOWED_ISP_ENDPOINTS = {
-      "en-US": "https://api.amazonalexa.com"
+      "en-US": "https://api.amazonalexa.com",
     };
 
     const locale: string = _.get(this.rawEvent.request, "locale");
@@ -99,7 +99,7 @@ export class InSkillPurchase {
 
   public async buyByReferenceName(
     referenceName: string,
-    token: string
+    token: string,
   ): Promise<ConnectionsSendRequest> {
     const product:
       | services.monetization.InSkillProduct
@@ -110,7 +110,7 @@ export class InSkillPurchase {
 
   public async cancelByReferenceName(
     referenceName: string,
-    token: string
+    token: string,
   ): Promise<ConnectionsSendRequest> {
     const product:
       | services.monetization.InSkillProduct
@@ -122,7 +122,7 @@ export class InSkillPurchase {
   public async upsellByReferenceName(
     referenceName: string,
     upsellMessage: string,
-    token: string
+    token: string,
   ): Promise<ConnectionsSendRequest> {
     const product:
       | services.monetization.InSkillProduct
@@ -131,12 +131,12 @@ export class InSkillPurchase {
     return InSkillPurchase.upsell(
       _.get(product, "productId"),
       upsellMessage,
-      token
+      token,
     );
   }
 
   public async getProductByReferenceName(
-    referenceName: string
+    referenceName: string,
   ): Promise<services.monetization.InSkillProduct | object> {
     const result: services.monetization.InSkillProductsResponse = await this.getProductList();
 
@@ -149,12 +149,12 @@ export class InSkillPurchase {
     const options: any = {
       headers: {
         "Accept-Language": _.get(this.rawEvent.request, "locale"),
-        Authorization: `Bearer ${apiAccessToken}`,
-        "Content-Type": "application/json"
+        "Authorization": `Bearer ${apiAccessToken}`,
+        "Content-Type": "application/json",
       },
       json: true,
       method: "GET",
-      uri: `${apiEndpoint}/v1/users/~current/skills/~current/inSkillProducts`
+      uri: `${apiEndpoint}/v1/users/~current/skills/~current/inSkillProducts`,
     };
 
     return rp(options);

--- a/src/platforms/alexa/apis/InSkillPurchase.ts
+++ b/src/platforms/alexa/apis/InSkillPurchase.ts
@@ -91,7 +91,7 @@ export class InSkillPurchase {
       "en-US": "https://api.amazonalexa.com",
     };
 
-    const locale: string = this.rawEvent.request.locale;
+    const locale: string = _.get(this.rawEvent.request, 'locale');
     const endpoint: string = _.get(this.rawEvent, "context.System.apiEndpoint");
 
     return _.get(ALLOWED_ISP_ENDPOINTS, locale) === endpoint;
@@ -148,7 +148,7 @@ export class InSkillPurchase {
 
     const options: any = {
       headers: {
-        "Accept-Language": this.rawEvent.request.locale,
+        "Accept-Language": _.get(this.rawEvent.request, 'locale'),
         "Authorization": `Bearer ${apiAccessToken}`,
         "Content-Type": "application/json",
       },

--- a/src/platforms/alexa/apis/InSkillPurchase.ts
+++ b/src/platforms/alexa/apis/InSkillPurchase.ts
@@ -40,7 +40,7 @@ export class InSkillPurchase {
 
   public static cancel(
     productId: string,
-    token: string,
+    token: string
   ): ConnectionsSendRequest {
     return this.sendConnectionSendRequest("Cancel", productId, token);
   }
@@ -48,13 +48,13 @@ export class InSkillPurchase {
   public static upsell(
     productId: string,
     upsellMessage: string,
-    token: string,
+    token: string
   ): ConnectionsSendRequest {
     return this.sendConnectionSendRequest(
       "Upsell",
       productId,
       token,
-      upsellMessage,
+      upsellMessage
     );
   }
 
@@ -62,7 +62,7 @@ export class InSkillPurchase {
     method: string,
     productId: string,
     token: string,
-    upsellMessage?: string,
+    upsellMessage?: string
   ): ConnectionsSendRequest {
     const payload = this.formatPayload(productId, upsellMessage);
     return new ConnectionsSendRequest(method, payload, token);
@@ -70,13 +70,13 @@ export class InSkillPurchase {
 
   protected static formatPayload(
     productId: string,
-    upsellMessage?: string,
+    upsellMessage?: string
   ): IPurchasePayload {
     return {
       InSkillProduct: {
-        productId,
+        productId
       },
-      upsellMessage,
+      upsellMessage
     };
   }
 
@@ -88,10 +88,10 @@ export class InSkillPurchase {
 
   public isAllowed() {
     const ALLOWED_ISP_ENDPOINTS = {
-      "en-US": "https://api.amazonalexa.com",
+      "en-US": "https://api.amazonalexa.com"
     };
 
-    const locale: string = _.get(this.rawEvent.request, 'locale');
+    const locale: string = _.get(this.rawEvent.request, "locale");
     const endpoint: string = _.get(this.rawEvent, "context.System.apiEndpoint");
 
     return _.get(ALLOWED_ISP_ENDPOINTS, locale) === endpoint;
@@ -99,7 +99,7 @@ export class InSkillPurchase {
 
   public async buyByReferenceName(
     referenceName: string,
-    token: string,
+    token: string
   ): Promise<ConnectionsSendRequest> {
     const product:
       | services.monetization.InSkillProduct
@@ -110,7 +110,7 @@ export class InSkillPurchase {
 
   public async cancelByReferenceName(
     referenceName: string,
-    token: string,
+    token: string
   ): Promise<ConnectionsSendRequest> {
     const product:
       | services.monetization.InSkillProduct
@@ -122,7 +122,7 @@ export class InSkillPurchase {
   public async upsellByReferenceName(
     referenceName: string,
     upsellMessage: string,
-    token: string,
+    token: string
   ): Promise<ConnectionsSendRequest> {
     const product:
       | services.monetization.InSkillProduct
@@ -131,12 +131,12 @@ export class InSkillPurchase {
     return InSkillPurchase.upsell(
       _.get(product, "productId"),
       upsellMessage,
-      token,
+      token
     );
   }
 
   public async getProductByReferenceName(
-    referenceName: string,
+    referenceName: string
   ): Promise<services.monetization.InSkillProduct | object> {
     const result: services.monetization.InSkillProductsResponse = await this.getProductList();
 
@@ -148,13 +148,13 @@ export class InSkillPurchase {
 
     const options: any = {
       headers: {
-        "Accept-Language": _.get(this.rawEvent.request, 'locale'),
-        "Authorization": `Bearer ${apiAccessToken}`,
-        "Content-Type": "application/json",
+        "Accept-Language": _.get(this.rawEvent.request, "locale"),
+        Authorization: `Bearer ${apiAccessToken}`,
+        "Content-Type": "application/json"
       },
       json: true,
       method: "GET",
-      uri: `${apiEndpoint}/v1/users/~current/skills/~current/inSkillProducts`,
+      uri: `${apiEndpoint}/v1/users/~current/skills/~current/inSkillProducts`
     };
 
     return rp(options);

--- a/src/platforms/alexa/index.ts
+++ b/src/platforms/alexa/index.ts
@@ -1,3 +1,4 @@
+export { AlexaCanFullfillReply } from "./AlexaCanFullfillReply";
 export { AlexaPlatform } from "./AlexaPlatform";
 export { AlexaReply } from "./AlexaReply";
 export { AlexaEvent } from "./AlexaEvent";

--- a/test/Renderer.spec.ts
+++ b/test/Renderer.spec.ts
@@ -13,7 +13,7 @@ import {
   Model,
   PlayAudio,
   Renderer,
-  VoxaApp,
+  VoxaApp
 } from "../src";
 import { AlexaRequestBuilder } from "./tools";
 import { variables } from "./variables";
@@ -32,7 +32,7 @@ describe("Renderer", () => {
     i18n.init({
       load: "all",
       nonExplicitWhitelist: true,
-      resources: views,
+      resources: views
     });
   });
 
@@ -50,7 +50,7 @@ describe("Renderer", () => {
       endState: { ask: "ExitIntent.Farewell", to: "die" },
       initState: { to: "endState" },
       secondState: { to: "initState" },
-      thirdState: () => Promise.resolve({ to: "endState" }),
+      thirdState: () => Promise.resolve({ to: "endState" })
     };
   });
 
@@ -59,14 +59,14 @@ describe("Renderer", () => {
       number: "ein",
       question: "wie spät ist es?",
       say: "sagen\nwie spät ist es?",
-      site: "Ok für weitere Infos besuchen example.com Website",
+      site: "Ok für weitere Infos besuchen example.com Website"
     },
     "en-US": {
       number: "one",
       question: "What time is it?",
       say: "say\nWhat time is it?",
-      site: "Ok. For more info visit example.com site.",
-    },
+      site: "Ok. For more info visit example.com site."
+    }
   };
 
   it("should launch an exception if no views are provided", () => {
@@ -82,7 +82,7 @@ describe("Renderer", () => {
     const reply = await skill.execute(event, new AlexaReply());
     // expect(reply.error.message).to.equal(`View Number.One for ${localeMissing} locale is missing`);
     expect(reply.speech).to.equal(
-      "<speak>An unrecoverable error occurred.</speak>",
+      "<speak>An unrecoverable error occurred.</speak>"
     );
   });
 
@@ -98,9 +98,9 @@ describe("Renderer", () => {
 
       it(`should return the correct translation for ${locale}`, async () => {
         _.map(statesDefinition, (state, name: string) =>
-          skill.onState(name, state),
+          skill.onState(name, state)
         );
-        _.set(rawEvent.request, 'locale', locale);
+        _.set(rawEvent.request, "locale", locale);
         const reply = await skill.execute(rawEvent);
         expect(reply.speech).to.equal(`<speak>${translations.site}</speak>`);
         expect(reply.response.directives).to.be.undefined;
@@ -110,19 +110,19 @@ describe("Renderer", () => {
         skill.onIntent("SomeIntent", () => ({
           ask: "Ask",
           say: "Say",
-          to: "entry",
+          to: "entry"
         }));
-        _.set(rawEvent.request, 'locale', locale);
+        _.set(rawEvent.request, "locale", locale);
         const reply = await skill.execute(rawEvent);
         expect(reply.speech).to.deep.equal(
-          `<speak>${translations.say}</speak>`,
+          `<speak>${translations.say}</speak>`
         );
         expect(reply.response.directives).to.be.undefined;
       });
 
       it("should have the locale available in variables", async () => {
         skill.onIntent("SomeIntent", () => ({ tell: "Number.One" }));
-        _.set(rawEvent.request, 'locale', locale);
+        _.set(rawEvent.request, "locale", locale);
         const reply = await skill.execute(rawEvent);
         expect(reply.speech).to.equal(`<speak>${translations.number}</speak>`);
         expect(reply.response.directives).to.be.undefined;
@@ -134,12 +134,12 @@ describe("Renderer", () => {
         skill.onIntent("SomeIntent", () => ({
           ask: "Ask",
           directives: [playAudio],
-          to: "entry",
+          to: "entry"
         }));
-        _.set(rawEvent.request, 'locale', locale);
+        _.set(rawEvent.request, "locale", locale);
         const reply = await skill.execute(rawEvent);
         expect(reply.speech).to.equal(
-          `<speak>${translations.question}</speak>`,
+          `<speak>${translations.question}</speak>`
         );
         expect(reply.response.directives).to.be.ok;
       });
@@ -150,7 +150,7 @@ describe("Renderer", () => {
     const rendered = await renderer.renderPath("Ask", event);
     expect(rendered).to.deep.equal({
       ask: "What time is it?",
-      reprompt: "What time is it?",
+      reprompt: "What time is it?"
     });
   });
 
@@ -161,25 +161,25 @@ describe("Renderer", () => {
     expect(rendered).to.deep.equal({ say: "1" });
   });
 
-  it("should fail for missing variables", (done) => {
+  it("should fail for missing variables", done => {
     renderer
       .renderMessage({ say: "{missing}" }, event)
       .then(() => done("Should have failed"))
-      .catch((error) => {
+      .catch(error => {
         expect(error.message).to.equal("No such variable in views, missing");
         done();
       });
   });
 
-  it("should throw an exception if path doesn't exists", (done) => {
+  it("should throw an exception if path doesn't exists", done => {
     renderer.renderPath("Missing.Path", event).then(
       () => done("Should have thrown"),
-      (error) => {
+      error => {
         expect(error.message).to.equal(
-          "View Missing.Path for en-US locale is missing",
+          "View Missing.Path for en-US locale is missing"
         );
         done();
-      },
+      }
     );
   });
 
@@ -188,20 +188,20 @@ describe("Renderer", () => {
     event.model.count = 1;
     const rendered = await renderer.renderMessage(
       { card: "{exitCard}", number: 1 },
-      event,
+      event
     );
 
     expect(rendered).to.deep.equal({
       card: {
         image: {
           largeImageUrl: "largeImage.jpg",
-          smallImageUrl: "smallImage.jpg",
+          smallImageUrl: "smallImage.jpg"
         },
         text: "text",
         title: "title",
-        type: "Standard",
+        type: "Standard"
       },
-      number: 1,
+      number: 1
     });
   });
 
@@ -210,17 +210,17 @@ describe("Renderer", () => {
     event.model.count = 1;
     const rendered = await renderer.renderMessage(
       {
-        card: { title: "{count}", text: "{count}", array: [{ a: "{count}" }] },
+        card: { title: "{count}", text: "{count}", array: [{ a: "{count}" }] }
       },
-      event,
+      event
     );
 
     expect(rendered).to.deep.equal({
       card: {
         array: [{ a: "1" }],
         text: "1",
-        title: "1",
-      },
+        title: "1"
+      }
     });
   });
 
@@ -232,13 +232,13 @@ describe("Renderer", () => {
   it("should use the dialogFlow view if available", async () => {
     const dialogFlowEvent = new DialogFlowEvent(
       require("./requests/dialogflow/launchIntent.json"),
-      {},
+      {}
     );
     dialogFlowEvent.t = event.t;
     dialogFlowEvent.platform = new DialogFlowPlatform(voxaApp);
     const rendered = await renderer.renderPath(
       "LaunchIntent.OpenResponse",
-      dialogFlowEvent,
+      dialogFlowEvent
     );
     expect(rendered).to.equal("Hello from DialogFlow");
   });

--- a/test/Renderer.spec.ts
+++ b/test/Renderer.spec.ts
@@ -13,7 +13,7 @@ import {
   Model,
   PlayAudio,
   Renderer,
-  VoxaApp
+  VoxaApp,
 } from "../src";
 import { AlexaRequestBuilder } from "./tools";
 import { variables } from "./variables";
@@ -32,7 +32,7 @@ describe("Renderer", () => {
     i18n.init({
       load: "all",
       nonExplicitWhitelist: true,
-      resources: views
+      resources: views,
     });
   });
 
@@ -50,7 +50,7 @@ describe("Renderer", () => {
       endState: { ask: "ExitIntent.Farewell", to: "die" },
       initState: { to: "endState" },
       secondState: { to: "initState" },
-      thirdState: () => Promise.resolve({ to: "endState" })
+      thirdState: () => Promise.resolve({ to: "endState" }),
     };
   });
 
@@ -59,14 +59,14 @@ describe("Renderer", () => {
       number: "ein",
       question: "wie spät ist es?",
       say: "sagen\nwie spät ist es?",
-      site: "Ok für weitere Infos besuchen example.com Website"
+      site: "Ok für weitere Infos besuchen example.com Website",
     },
     "en-US": {
       number: "one",
       question: "What time is it?",
       say: "say\nWhat time is it?",
-      site: "Ok. For more info visit example.com site."
-    }
+      site: "Ok. For more info visit example.com site.",
+    },
   };
 
   it("should launch an exception if no views are provided", () => {
@@ -82,7 +82,7 @@ describe("Renderer", () => {
     const reply = await skill.execute(event, new AlexaReply());
     // expect(reply.error.message).to.equal(`View Number.One for ${localeMissing} locale is missing`);
     expect(reply.speech).to.equal(
-      "<speak>An unrecoverable error occurred.</speak>"
+      "<speak>An unrecoverable error occurred.</speak>",
     );
   });
 
@@ -98,7 +98,7 @@ describe("Renderer", () => {
 
       it(`should return the correct translation for ${locale}`, async () => {
         _.map(statesDefinition, (state, name: string) =>
-          skill.onState(name, state)
+          skill.onState(name, state),
         );
         _.set(rawEvent.request, "locale", locale);
         const reply = await skill.execute(rawEvent);
@@ -110,12 +110,12 @@ describe("Renderer", () => {
         skill.onIntent("SomeIntent", () => ({
           ask: "Ask",
           say: "Say",
-          to: "entry"
+          to: "entry",
         }));
         _.set(rawEvent.request, "locale", locale);
         const reply = await skill.execute(rawEvent);
         expect(reply.speech).to.deep.equal(
-          `<speak>${translations.say}</speak>`
+          `<speak>${translations.say}</speak>`,
         );
         expect(reply.response.directives).to.be.undefined;
       });
@@ -134,12 +134,12 @@ describe("Renderer", () => {
         skill.onIntent("SomeIntent", () => ({
           ask: "Ask",
           directives: [playAudio],
-          to: "entry"
+          to: "entry",
         }));
         _.set(rawEvent.request, "locale", locale);
         const reply = await skill.execute(rawEvent);
         expect(reply.speech).to.equal(
-          `<speak>${translations.question}</speak>`
+          `<speak>${translations.question}</speak>`,
         );
         expect(reply.response.directives).to.be.ok;
       });
@@ -150,7 +150,7 @@ describe("Renderer", () => {
     const rendered = await renderer.renderPath("Ask", event);
     expect(rendered).to.deep.equal({
       ask: "What time is it?",
-      reprompt: "What time is it?"
+      reprompt: "What time is it?",
     });
   });
 
@@ -161,25 +161,25 @@ describe("Renderer", () => {
     expect(rendered).to.deep.equal({ say: "1" });
   });
 
-  it("should fail for missing variables", done => {
+  it("should fail for missing variables", (done) => {
     renderer
       .renderMessage({ say: "{missing}" }, event)
       .then(() => done("Should have failed"))
-      .catch(error => {
+      .catch((error) => {
         expect(error.message).to.equal("No such variable in views, missing");
         done();
       });
   });
 
-  it("should throw an exception if path doesn't exists", done => {
+  it("should throw an exception if path doesn't exists", (done) => {
     renderer.renderPath("Missing.Path", event).then(
       () => done("Should have thrown"),
-      error => {
+      (error) => {
         expect(error.message).to.equal(
-          "View Missing.Path for en-US locale is missing"
+          "View Missing.Path for en-US locale is missing",
         );
         done();
-      }
+      },
     );
   });
 
@@ -188,20 +188,20 @@ describe("Renderer", () => {
     event.model.count = 1;
     const rendered = await renderer.renderMessage(
       { card: "{exitCard}", number: 1 },
-      event
+      event,
     );
 
     expect(rendered).to.deep.equal({
       card: {
         image: {
           largeImageUrl: "largeImage.jpg",
-          smallImageUrl: "smallImage.jpg"
+          smallImageUrl: "smallImage.jpg",
         },
         text: "text",
         title: "title",
-        type: "Standard"
+        type: "Standard",
       },
-      number: 1
+      number: 1,
     });
   });
 
@@ -210,17 +210,17 @@ describe("Renderer", () => {
     event.model.count = 1;
     const rendered = await renderer.renderMessage(
       {
-        card: { title: "{count}", text: "{count}", array: [{ a: "{count}" }] }
+        card: { title: "{count}", text: "{count}", array: [{ a: "{count}" }] },
       },
-      event
+      event,
     );
 
     expect(rendered).to.deep.equal({
       card: {
         array: [{ a: "1" }],
         text: "1",
-        title: "1"
-      }
+        title: "1",
+      },
     });
   });
 
@@ -232,13 +232,13 @@ describe("Renderer", () => {
   it("should use the dialogFlow view if available", async () => {
     const dialogFlowEvent = new DialogFlowEvent(
       require("./requests/dialogflow/launchIntent.json"),
-      {}
+      {},
     );
     dialogFlowEvent.t = event.t;
     dialogFlowEvent.platform = new DialogFlowPlatform(voxaApp);
     const rendered = await renderer.renderPath(
       "LaunchIntent.OpenResponse",
-      dialogFlowEvent
+      dialogFlowEvent,
     );
     expect(rendered).to.equal("Hello from DialogFlow");
   });

--- a/test/Renderer.spec.ts
+++ b/test/Renderer.spec.ts
@@ -100,7 +100,7 @@ describe("Renderer", () => {
         _.map(statesDefinition, (state, name: string) =>
           skill.onState(name, state),
         );
-        rawEvent.request.locale = locale;
+        _.set(rawEvent.request, 'locale', locale);
         const reply = await skill.execute(rawEvent);
         expect(reply.speech).to.equal(`<speak>${translations.site}</speak>`);
         expect(reply.response.directives).to.be.undefined;
@@ -112,7 +112,7 @@ describe("Renderer", () => {
           say: "Say",
           to: "entry",
         }));
-        rawEvent.request.locale = locale;
+        _.set(rawEvent.request, 'locale', locale);
         const reply = await skill.execute(rawEvent);
         expect(reply.speech).to.deep.equal(
           `<speak>${translations.say}</speak>`,
@@ -122,7 +122,7 @@ describe("Renderer", () => {
 
       it("should have the locale available in variables", async () => {
         skill.onIntent("SomeIntent", () => ({ tell: "Number.One" }));
-        rawEvent.request.locale = locale;
+        _.set(rawEvent.request, 'locale', locale);
         const reply = await skill.execute(rawEvent);
         expect(reply.speech).to.equal(`<speak>${translations.number}</speak>`);
         expect(reply.response.directives).to.be.undefined;
@@ -136,7 +136,7 @@ describe("Renderer", () => {
           directives: [playAudio],
           to: "entry",
         }));
-        rawEvent.request.locale = locale;
+        _.set(rawEvent.request, 'locale', locale);
         const reply = await skill.execute(rawEvent);
         expect(reply.speech).to.equal(
           `<speak>${translations.question}</speak>`,

--- a/test/VoxaApp.spec.ts
+++ b/test/VoxaApp.spec.ts
@@ -22,11 +22,11 @@
 
 import "mocha";
 
-import { canfulfill } from "../src/platforms/alexa/CanFullfillintent";
 import { RequestEnvelope } from "ask-sdk-model";
 import { expect } from "chai";
 import * as _ from "lodash";
 import * as simple from "simple-mock";
+import { canfulfill } from "../src/platforms/alexa/CanFullfillintent";
 
 import {
   AlexaEvent,
@@ -37,7 +37,7 @@ import {
   IVoxaReply,
   Model,
   State,
-  VoxaApp
+  VoxaApp,
 } from "../src";
 import { AlexaRequestBuilder } from "./tools";
 import { variables } from "./variables";
@@ -60,7 +60,7 @@ describe("VoxaApp", () => {
       SomeIntent: { tell: "ExitIntent.Farewell", to: "die" },
       initState: { to: "endState" },
       secondState: { to: "initState" },
-      thirdState: () => Promise.resolve({ to: "endState" })
+      thirdState: () => Promise.resolve({ to: "endState" }),
     };
   });
 
@@ -77,7 +77,7 @@ describe("VoxaApp", () => {
     launchEvent.platform = platform;
     const reply = (await voxaApp.execute(
       launchEvent,
-      new AlexaReply()
+      new AlexaReply(),
     )) as AlexaReply;
     expect(reply.sessionAttributes.state).to.equal("secondState");
     expect(reply.response.shouldEndSession).to.be.false;
@@ -86,7 +86,7 @@ describe("VoxaApp", () => {
   it("should include outputAttributes in the session attributes", async () => {
     const voxaApp = new VoxaApp({ variables, views });
     const platform = new AlexaPlatform(voxaApp);
-    voxaApp.onIntent("LaunchIntent", request => {
+    voxaApp.onIntent("LaunchIntent", (request) => {
       request.session.outputAttributes.foo = "bar";
       return { to: "secondState", sayp: "This is my message", flow: "yield" };
     });
@@ -96,7 +96,7 @@ describe("VoxaApp", () => {
     launchEvent.platform = platform;
     const reply = (await voxaApp.execute(
       launchEvent,
-      new AlexaReply()
+      new AlexaReply(),
     )) as AlexaReply;
     expect(reply.sessionAttributes.foo).to.equal("bar");
   });
@@ -110,7 +110,7 @@ describe("VoxaApp", () => {
 
     const reply = (await voxaApp.execute(
       launchEvent,
-      new AlexaReply()
+      new AlexaReply(),
     )) as AlexaReply;
     expect(reply.speech).to.deep.equal("<speak>This is my message</speak>");
   });
@@ -124,18 +124,18 @@ describe("VoxaApp", () => {
 
     const reply = (await voxaApp.execute(
       launchEvent,
-      new AlexaReply()
+      new AlexaReply(),
     )) as AlexaReply;
     // expect(reply.error).to.be.an("error");
     expect(reply.speech).to.equal(
-      "<speak>An unrecoverable error occurred.</speak>"
+      "<speak>An unrecoverable error occurred.</speak>",
     );
   });
 
   it("should allow multiple reply paths in reply key", async () => {
     const voxaApp = new VoxaApp({ variables, views });
     const platform = new AlexaPlatform(voxaApp);
-    voxaApp.onIntent("LaunchIntent", voxaEvent => {
+    voxaApp.onIntent("LaunchIntent", (voxaEvent) => {
       voxaEvent.model.count = 0;
       return { say: ["Count.Say", "Count.Tell"] };
     });
@@ -144,7 +144,7 @@ describe("VoxaApp", () => {
 
     const reply = (await voxaApp.execute(
       launchEvent,
-      new AlexaReply()
+      new AlexaReply(),
     )) as AlexaReply;
     expect(reply.speech).to.deep.equal("<speak>0\n0</speak>");
   });
@@ -154,13 +154,13 @@ describe("VoxaApp", () => {
     const alexaEvent = rb.getDisplayElementSelectedRequest("token");
     voxaApp.onIntent("Display.ElementSelected", {
       tell: "ExitIntent.Farewell",
-      to: "die"
+      to: "die",
     });
 
     const alexaSkill = new AlexaPlatform(voxaApp);
     const reply = await alexaSkill.execute(alexaEvent);
     expect(_.get(reply, "response.outputSpeech.ssml")).to.equal(
-      "<speak>Ok. For more info visit example.com site.</speak>"
+      "<speak>Ok. For more info visit example.com site.</speak>",
     );
   });
 
@@ -191,14 +191,14 @@ describe("VoxaApp", () => {
       voxaApp.onBeforeStateChanged(
         (voxaEvent: IVoxaEvent, voxaReply: IVoxaReply, state: State) => {
           voxaEvent.model.previousState = state.name;
-        }
+        },
       );
 
       voxaApp.onIntent("SomeIntent", (voxaEvent: IVoxaIntentEvent) => {
         expect(voxaEvent.model.previousState).to.equal("SomeIntent");
         return {
           flow: "terminate",
-          sayp: "done"
+          sayp: "done",
         };
       });
 
@@ -210,7 +210,7 @@ describe("VoxaApp", () => {
 
   it("should set properties on request and have those available in the state callbacks", async () => {
     const voxaApp = new VoxaApp({ views, variables });
-    statesDefinition.SomeIntent = simple.spy(request => {
+    statesDefinition.SomeIntent = simple.spy((request) => {
       expect(request.model).to.not.be.undefined;
       expect(request.model).to.be.an.instanceOf(Model);
 
@@ -218,7 +218,7 @@ describe("VoxaApp", () => {
     });
 
     _.map(statesDefinition, (state: any, name: string) =>
-      voxaApp.onState(name, state)
+      voxaApp.onState(name, state),
     );
 
     const platform = new AlexaPlatform(voxaApp);
@@ -247,20 +247,20 @@ describe("VoxaApp", () => {
       public serialize() {
         // eslint-disable-line class-methods-use-this
         return Promise.resolve({
-          value: 1
+          value: 1,
         });
       }
     }
 
     const voxaApp = new VoxaApp({ views, variables, Model: PromisyModel });
-    statesDefinition.SomeIntent = simple.spy(request => {
+    statesDefinition.SomeIntent = simple.spy((request) => {
       expect(request.model).to.not.be.undefined;
       expect(request.model).to.be.an.instanceOf(PromisyModel);
       return { ask: "Ask", to: "initState" };
     });
 
     _.map(statesDefinition, (state: any, name: string) =>
-      voxaApp.onState(name, state)
+      voxaApp.onState(name, state),
     );
     const platform = new AlexaPlatform(voxaApp);
     const reply = (await platform.execute(event)) as AlexaReply;
@@ -268,7 +268,7 @@ describe("VoxaApp", () => {
     expect(statesDefinition.SomeIntent.lastCall.threw).to.be.not.ok;
     expect(reply.sessionAttributes).to.deep.equal({
       model: { value: 1 },
-      state: "initState"
+      state: "initState",
     });
   });
 
@@ -286,7 +286,7 @@ describe("VoxaApp", () => {
     const alexaEvent = new AlexaEvent(event);
     alexaEvent.platform = platform;
 
-    statesDefinition.SomeIntent = simple.spy(request => {
+    statesDefinition.SomeIntent = simple.spy((request) => {
       expect(request.model).to.not.be.undefined;
       expect(request.model).to.be.an.instanceOf(PromisyModel);
       expect(request.model.didDeserialize).to.eql("yep");
@@ -294,7 +294,7 @@ describe("VoxaApp", () => {
     });
 
     _.map(statesDefinition, (state: any, name: string) =>
-      voxaApp.onState(name, state)
+      voxaApp.onState(name, state),
     );
 
     const sessionEvent = rb.getIntentRequest("SomeIntent");
@@ -310,7 +310,7 @@ describe("VoxaApp", () => {
     const platform = new AlexaPlatform(voxaApp);
     const alexaEvent = event;
     _.map(statesDefinition, (state: any, name: string) =>
-      voxaApp.onState(name, state)
+      voxaApp.onState(name, state),
     );
     const onSessionEnded = simple.stub();
     voxaApp.onSessionEnded(onSessionEnded);
@@ -325,7 +325,7 @@ describe("VoxaApp", () => {
     const alexaEvent = new AlexaEvent(event);
     alexaEvent.platform = platform;
     _.map(statesDefinition, (state: any, name: string) =>
-      voxaApp.onState(name, state)
+      voxaApp.onState(name, state),
     );
     const onBeforeReplySent = simple.stub();
     voxaApp.onBeforeReplySent(onBeforeReplySent);
@@ -340,9 +340,9 @@ describe("VoxaApp", () => {
       slots: {
         slot1: {
           canFulfill: "YES",
-          canUnderstand: "YES"
-        }
-      }
+          canUnderstand: "YES",
+        },
+      },
     };
 
     const voxaApp = new VoxaApp({ views, variables });
@@ -352,11 +352,11 @@ describe("VoxaApp", () => {
         alexaReply.fulfillIntent("YES");
         alexaReply.fulfillSlot("slot1", "YES", "YES");
         return alexaReply;
-      }
+      },
     );
 
     event = rb.getCanFulfillIntentRequestRequest("NameIntent", {
-      slot1: "something"
+      slot1: "something",
     });
     const reply = (await alexaSkill.execute(event)) as AlexaReply;
 
@@ -372,9 +372,9 @@ describe("VoxaApp", () => {
       slots: {
         slot1: {
           canFulfill: "YES",
-          canUnderstand: "YES"
-        }
-      }
+          canUnderstand: "YES",
+        },
+      },
     };
 
     const defaultFulfillIntents = ["NameIntent"];
@@ -382,7 +382,7 @@ describe("VoxaApp", () => {
     const alexaSkill = new AlexaPlatform(voxaApp, { defaultFulfillIntents });
 
     event = rb.getCanFulfillIntentRequestRequest("NameIntent", {
-      slot1: "something"
+      slot1: "something",
     });
     const reply = (await alexaSkill.execute(event)) as AlexaReply;
 
@@ -398,9 +398,9 @@ describe("VoxaApp", () => {
       slots: {
         slot1: {
           canFulfill: "YES",
-          canUnderstand: "YES"
-        }
-      }
+          canUnderstand: "YES",
+        },
+      },
     };
 
     const voxaApp = new VoxaApp({ views, variables });
@@ -410,11 +410,11 @@ describe("VoxaApp", () => {
         alexaReply.fulfillIntent("MAYBE");
         alexaReply.fulfillSlot("slot1", "YES", "YES");
         return alexaReply;
-      }
+      },
     );
 
     event = rb.getCanFulfillIntentRequestRequest("NameIntent", {
-      slot1: "something"
+      slot1: "something",
     });
     const reply = (await alexaSkill.execute(event)) as AlexaReply;
 
@@ -426,7 +426,7 @@ describe("VoxaApp", () => {
 
   it("should not fulfill request", async () => {
     const canFulfillIntent: canfulfill.CanFulfillIntent = {
-      canFulfill: "NO"
+      canFulfill: "NO",
     };
 
     const voxaApp = new VoxaApp({ views, variables });
@@ -435,11 +435,11 @@ describe("VoxaApp", () => {
       (alexaEvent: AlexaEvent, alexaReply: AlexaReply) => {
         alexaReply.fulfillIntent("NO");
         return alexaReply;
-      }
+      },
     );
 
     event = rb.getCanFulfillIntentRequestRequest("NameIntent", {
-      slot1: "something"
+      slot1: "something",
     });
     const reply = (await alexaSkill.execute(event)) as AlexaReply;
 
@@ -455,9 +455,9 @@ describe("VoxaApp", () => {
       slots: {
         slot1: {
           canFulfill: "NO",
-          canUnderstand: "NO"
-        }
-      }
+          canUnderstand: "NO",
+        },
+      },
     };
 
     const voxaApp = new VoxaApp({ views, variables });
@@ -467,11 +467,11 @@ describe("VoxaApp", () => {
         alexaReply.fulfillIntent("yes");
         alexaReply.fulfillSlot("slot1", "yes", "yes");
         return alexaReply;
-      }
+      },
     );
 
     event = rb.getCanFulfillIntentRequestRequest("NameIntent", {
-      slot1: "something"
+      slot1: "something",
     });
     const reply = (await alexaSkill.execute(event)) as AlexaReply;
 
@@ -490,11 +490,11 @@ describe("VoxaApp", () => {
       statesDefinition.LaunchIntent = simple.stub().resolveWith(null);
 
       _.map(statesDefinition, (state: any, name: string) =>
-        voxaApp.onState(name, state)
+        voxaApp.onState(name, state),
       );
       const reply = await platform.execute(launchEvent);
       expect(reply.speech).to.equal(
-        "<speak>An unrecoverable error occurred.</speak>"
+        "<speak>An unrecoverable error occurred.</speak>",
       );
     });
 
@@ -505,22 +505,22 @@ describe("VoxaApp", () => {
       const onUnhandledState = simple.stub().returnWith(
         Promise.resolve({
           flow: "terminate",
-          sayp: "Unhandled State"
-        })
+          sayp: "Unhandled State",
+        }),
       );
 
       voxaApp.onUnhandledState(onUnhandledState);
       voxaApp.onIntent("LaunchIntent", {
-        to: "otherState"
+        to: "otherState",
       });
 
       voxaApp.onState(
         "otherState",
         {
           flow: "terminate",
-          sayp: "Other State"
+          sayp: "Other State",
         },
-        "SomeIntent"
+        "SomeIntent",
       );
 
       const platform = new AlexaPlatform(voxaApp);
@@ -539,8 +539,8 @@ describe("VoxaApp", () => {
         const onUnhandledState = simple.stub().returnWith(
           Promise.resolve({
             tell: "ExitIntent.Farewell",
-            to: "die"
-          })
+            to: "die",
+          }),
         );
 
         voxaApp.onUnhandledState(onUnhandledState);
@@ -548,14 +548,14 @@ describe("VoxaApp", () => {
         statesDefinition.LaunchIntent = simple.stub().resolveWith(null);
 
         _.map(statesDefinition, (state: any, name: string) =>
-          voxaApp.onState(name, state)
+          voxaApp.onState(name, state),
         );
         const reply = await platform.execute(launchEvent);
         expect(onUnhandledState.called).to.be.true;
         expect(reply.speech).to.equal(
-          "<speak>Ok. For more info visit example.com site.</speak>"
+          "<speak>Ok. For more info visit example.com site.</speak>",
         );
-      }
+      },
     );
 
     it("should call onUnhandledState for intents without a handler", async () => {
@@ -565,8 +565,8 @@ describe("VoxaApp", () => {
       const onUnhandledState = simple.stub().returnWith(
         Promise.resolve({
           tell: "ExitIntent.Farewell",
-          to: "die"
-        })
+          to: "die",
+        }),
       );
 
       voxaApp.onUnhandledState(onUnhandledState);
@@ -574,12 +574,12 @@ describe("VoxaApp", () => {
       statesDefinition.LaunchIntent = simple.stub().resolveWith(null);
 
       _.map(statesDefinition, (state: any, name: string) =>
-        voxaApp.onState(name, state)
+        voxaApp.onState(name, state),
       );
       const reply = await platform.execute(launchEvent);
       expect(onUnhandledState.called).to.be.true;
       expect(reply.speech).to.equal(
-        "<speak>Ok. For more info visit example.com site.</speak>"
+        "<speak>Ok. For more info visit example.com site.</speak>",
       );
     });
   });
@@ -595,12 +595,12 @@ describe("VoxaApp", () => {
     voxaApp.onIntent("SomeIntent", () => ({
       directives,
       tell: "ExitIntent.Farewell",
-      to: "entry"
+      to: "entry",
     }));
 
     const reply = (await voxaApp.execute(
       alexaEvent,
-      new AlexaReply()
+      new AlexaReply(),
     )) as AlexaReply;
     expect(reply.response.directives).to.not.be.undefined;
     expect(reply.response.directives).to.have.length(1);
@@ -611,12 +611,12 @@ describe("VoxaApp", () => {
           stream: {
             offsetInMilliseconds: 0,
             token: "123",
-            url: "url"
-          }
+            url: "url",
+          },
         },
         playBehavior: "REPLACE_ALL",
-        type: "AudioPlayer.Play"
-      }
+        type: "AudioPlayer.Play",
+      },
     ]);
   });
 
@@ -630,12 +630,12 @@ describe("VoxaApp", () => {
 
     voxaApp.onIntent("SomeIntent", () => ({
       directives,
-      say: "ExitIntent.Farewell"
+      say: "ExitIntent.Farewell",
     }));
 
     const reply = (await voxaApp.execute(
       alexaEvent,
-      new AlexaReply()
+      new AlexaReply(),
     )) as AlexaReply;
     expect(reply.response.directives).to.not.be.undefined;
     expect(reply.response.directives).to.have.length(1);
@@ -646,12 +646,12 @@ describe("VoxaApp", () => {
           stream: {
             offsetInMilliseconds: 0,
             token: "123",
-            url: "url"
-          }
+            url: "url",
+          },
         },
         playBehavior: "REPLACE_ALL",
-        type: "AudioPlayer.Play"
-      }
+        type: "AudioPlayer.Play",
+      },
     ]);
   });
 
@@ -662,7 +662,7 @@ describe("VoxaApp", () => {
     const alexaEvent = launchEvent;
 
     statesDefinition.LaunchIntent = {
-      to: "fourthState"
+      to: "fourthState",
     };
 
     statesDefinition.fourthState = (request: IVoxaEvent) => {
@@ -676,7 +676,7 @@ describe("VoxaApp", () => {
     };
 
     _.map(statesDefinition, (state: any, name: string) =>
-      voxaApp.onState(name, state)
+      voxaApp.onState(name, state),
     );
     const reply = await platform.execute(alexaEvent);
     expect(reply.speech).to.deep.equal("<speak>0\n1</speak>");
@@ -688,7 +688,7 @@ describe("VoxaApp", () => {
     const alexaEvent = new AlexaEvent(event);
     alexaEvent.platform = platform;
     _.map(statesDefinition, (state: any, name: string) =>
-      voxaApp.onState(name, state)
+      voxaApp.onState(name, state),
     );
     const stubResponse = "STUB RESPONSE";
     const stub = simple.stub().resolveWith(stubResponse);
@@ -696,12 +696,12 @@ describe("VoxaApp", () => {
 
     const reply = (await voxaApp.execute(
       alexaEvent,
-      new AlexaReply()
+      new AlexaReply(),
     )) as AlexaReply;
     expect(stub.called).to.be.true;
     expect(reply).to.not.equal(stubResponse);
     expect(reply.speech).to.equal(
-      "<speak>Ok. For more info visit example.com site.</speak>"
+      "<speak>Ok. For more info visit example.com site.</speak>",
     );
   });
 
@@ -732,15 +732,15 @@ describe("VoxaApp", () => {
       voxaApp.onIntent("LaunchIntent", {
         flow: "yield",
         reply: "Reply.Say",
-        to: "entry"
+        to: "entry",
       });
       const response = (await voxaApp.execute(
         launchEvent,
-        new AlexaReply()
+        new AlexaReply(),
       )) as AlexaReply;
       expect(response.speech).to.deep.equal("<speak>this is a say</speak>");
       expect(response.reprompt).to.deep.equal(
-        "<speak>this is a reprompt</speak>"
+        "<speak>this is a reprompt</speak>",
       );
       expect(response.hasTerminated).to.be.false;
     });
@@ -752,31 +752,31 @@ describe("VoxaApp", () => {
         reply: "Reply.Card",
         reprompt: "Reprompt",
         say: "Say",
-        to: "entry"
+        to: "entry",
       });
       const alexaSkill = new AlexaPlatform(voxaApp);
       const response = await alexaSkill.execute(event);
 
       expect(_.get(response, "response.outputSpeech.ssml")).to.deep.equal(
-        "<speak>say</speak>"
+        "<speak>say</speak>",
       );
       expect(
-        _.get(response, "response.reprompt.outputSpeech.ssml")
+        _.get(response, "response.reprompt.outputSpeech.ssml"),
       ).to.deep.equal("<speak>reprompt</speak>");
       expect(response.response.card).to.deep.equal({
         image: {
           largeImageUrl: "https://example.com/large.jpg",
-          smallImageUrl: "https://example.com/small.jpg"
+          smallImageUrl: "https://example.com/small.jpg",
         },
         title: "Title",
-        type: "Standard"
+        type: "Standard",
       });
       expect(_.get(response, "response.directives[0]")).to.deep.equal({
         hint: {
           text: "this is the hint",
-          type: "PlainText"
+          type: "PlainText",
         },
-        type: "Hint"
+        type: "Hint",
       });
     });
   });

--- a/test/VoxaApp.spec.ts
+++ b/test/VoxaApp.spec.ts
@@ -22,7 +22,7 @@
 
 import "mocha";
 
-import { canfulfill } from '../src/platforms/alexa/CanFullfillintent';
+import { canfulfill } from "../src/platforms/alexa/CanFullfillintent";
 import { RequestEnvelope } from "ask-sdk-model";
 import { expect } from "chai";
 import * as _ from "lodash";
@@ -37,7 +37,7 @@ import {
   IVoxaReply,
   Model,
   State,
-  VoxaApp,
+  VoxaApp
 } from "../src";
 import { AlexaRequestBuilder } from "./tools";
 import { variables } from "./variables";
@@ -60,7 +60,7 @@ describe("VoxaApp", () => {
       SomeIntent: { tell: "ExitIntent.Farewell", to: "die" },
       initState: { to: "endState" },
       secondState: { to: "initState" },
-      thirdState: () => Promise.resolve({ to: "endState" }),
+      thirdState: () => Promise.resolve({ to: "endState" })
     };
   });
 
@@ -77,7 +77,7 @@ describe("VoxaApp", () => {
     launchEvent.platform = platform;
     const reply = (await voxaApp.execute(
       launchEvent,
-      new AlexaReply(),
+      new AlexaReply()
     )) as AlexaReply;
     expect(reply.sessionAttributes.state).to.equal("secondState");
     expect(reply.response.shouldEndSession).to.be.false;
@@ -86,7 +86,7 @@ describe("VoxaApp", () => {
   it("should include outputAttributes in the session attributes", async () => {
     const voxaApp = new VoxaApp({ variables, views });
     const platform = new AlexaPlatform(voxaApp);
-    voxaApp.onIntent("LaunchIntent", (request) => {
+    voxaApp.onIntent("LaunchIntent", request => {
       request.session.outputAttributes.foo = "bar";
       return { to: "secondState", sayp: "This is my message", flow: "yield" };
     });
@@ -96,7 +96,7 @@ describe("VoxaApp", () => {
     launchEvent.platform = platform;
     const reply = (await voxaApp.execute(
       launchEvent,
-      new AlexaReply(),
+      new AlexaReply()
     )) as AlexaReply;
     expect(reply.sessionAttributes.foo).to.equal("bar");
   });
@@ -110,7 +110,7 @@ describe("VoxaApp", () => {
 
     const reply = (await voxaApp.execute(
       launchEvent,
-      new AlexaReply(),
+      new AlexaReply()
     )) as AlexaReply;
     expect(reply.speech).to.deep.equal("<speak>This is my message</speak>");
   });
@@ -124,18 +124,18 @@ describe("VoxaApp", () => {
 
     const reply = (await voxaApp.execute(
       launchEvent,
-      new AlexaReply(),
+      new AlexaReply()
     )) as AlexaReply;
     // expect(reply.error).to.be.an("error");
     expect(reply.speech).to.equal(
-      "<speak>An unrecoverable error occurred.</speak>",
+      "<speak>An unrecoverable error occurred.</speak>"
     );
   });
 
   it("should allow multiple reply paths in reply key", async () => {
     const voxaApp = new VoxaApp({ variables, views });
     const platform = new AlexaPlatform(voxaApp);
-    voxaApp.onIntent("LaunchIntent", (voxaEvent) => {
+    voxaApp.onIntent("LaunchIntent", voxaEvent => {
       voxaEvent.model.count = 0;
       return { say: ["Count.Say", "Count.Tell"] };
     });
@@ -144,7 +144,7 @@ describe("VoxaApp", () => {
 
     const reply = (await voxaApp.execute(
       launchEvent,
-      new AlexaReply(),
+      new AlexaReply()
     )) as AlexaReply;
     expect(reply.speech).to.deep.equal("<speak>0\n0</speak>");
   });
@@ -154,13 +154,13 @@ describe("VoxaApp", () => {
     const alexaEvent = rb.getDisplayElementSelectedRequest("token");
     voxaApp.onIntent("Display.ElementSelected", {
       tell: "ExitIntent.Farewell",
-      to: "die",
+      to: "die"
     });
 
     const alexaSkill = new AlexaPlatform(voxaApp);
     const reply = await alexaSkill.execute(alexaEvent);
     expect(_.get(reply, "response.outputSpeech.ssml")).to.equal(
-      "<speak>Ok. For more info visit example.com site.</speak>",
+      "<speak>Ok. For more info visit example.com site.</speak>"
     );
   });
 
@@ -191,14 +191,14 @@ describe("VoxaApp", () => {
       voxaApp.onBeforeStateChanged(
         (voxaEvent: IVoxaEvent, voxaReply: IVoxaReply, state: State) => {
           voxaEvent.model.previousState = state.name;
-        },
+        }
       );
 
       voxaApp.onIntent("SomeIntent", (voxaEvent: IVoxaIntentEvent) => {
         expect(voxaEvent.model.previousState).to.equal("SomeIntent");
         return {
           flow: "terminate",
-          sayp: "done",
+          sayp: "done"
         };
       });
 
@@ -210,7 +210,7 @@ describe("VoxaApp", () => {
 
   it("should set properties on request and have those available in the state callbacks", async () => {
     const voxaApp = new VoxaApp({ views, variables });
-    statesDefinition.SomeIntent = simple.spy((request) => {
+    statesDefinition.SomeIntent = simple.spy(request => {
       expect(request.model).to.not.be.undefined;
       expect(request.model).to.be.an.instanceOf(Model);
 
@@ -218,7 +218,7 @@ describe("VoxaApp", () => {
     });
 
     _.map(statesDefinition, (state: any, name: string) =>
-      voxaApp.onState(name, state),
+      voxaApp.onState(name, state)
     );
 
     const platform = new AlexaPlatform(voxaApp);
@@ -247,20 +247,20 @@ describe("VoxaApp", () => {
       public serialize() {
         // eslint-disable-line class-methods-use-this
         return Promise.resolve({
-          value: 1,
+          value: 1
         });
       }
     }
 
     const voxaApp = new VoxaApp({ views, variables, Model: PromisyModel });
-    statesDefinition.SomeIntent = simple.spy((request) => {
+    statesDefinition.SomeIntent = simple.spy(request => {
       expect(request.model).to.not.be.undefined;
       expect(request.model).to.be.an.instanceOf(PromisyModel);
       return { ask: "Ask", to: "initState" };
     });
 
     _.map(statesDefinition, (state: any, name: string) =>
-      voxaApp.onState(name, state),
+      voxaApp.onState(name, state)
     );
     const platform = new AlexaPlatform(voxaApp);
     const reply = (await platform.execute(event)) as AlexaReply;
@@ -268,7 +268,7 @@ describe("VoxaApp", () => {
     expect(statesDefinition.SomeIntent.lastCall.threw).to.be.not.ok;
     expect(reply.sessionAttributes).to.deep.equal({
       model: { value: 1 },
-      state: "initState",
+      state: "initState"
     });
   });
 
@@ -286,7 +286,7 @@ describe("VoxaApp", () => {
     const alexaEvent = new AlexaEvent(event);
     alexaEvent.platform = platform;
 
-    statesDefinition.SomeIntent = simple.spy((request) => {
+    statesDefinition.SomeIntent = simple.spy(request => {
       expect(request.model).to.not.be.undefined;
       expect(request.model).to.be.an.instanceOf(PromisyModel);
       expect(request.model.didDeserialize).to.eql("yep");
@@ -294,7 +294,7 @@ describe("VoxaApp", () => {
     });
 
     _.map(statesDefinition, (state: any, name: string) =>
-      voxaApp.onState(name, state),
+      voxaApp.onState(name, state)
     );
 
     const sessionEvent = rb.getIntentRequest("SomeIntent");
@@ -310,7 +310,7 @@ describe("VoxaApp", () => {
     const platform = new AlexaPlatform(voxaApp);
     const alexaEvent = event;
     _.map(statesDefinition, (state: any, name: string) =>
-      voxaApp.onState(name, state),
+      voxaApp.onState(name, state)
     );
     const onSessionEnded = simple.stub();
     voxaApp.onSessionEnded(onSessionEnded);
@@ -325,7 +325,7 @@ describe("VoxaApp", () => {
     const alexaEvent = new AlexaEvent(event);
     alexaEvent.platform = platform;
     _.map(statesDefinition, (state: any, name: string) =>
-      voxaApp.onState(name, state),
+      voxaApp.onState(name, state)
     );
     const onBeforeReplySent = simple.stub();
     voxaApp.onBeforeReplySent(onBeforeReplySent);
@@ -340,9 +340,9 @@ describe("VoxaApp", () => {
       slots: {
         slot1: {
           canFulfill: "YES",
-          canUnderstand: "YES",
-        },
-      },
+          canUnderstand: "YES"
+        }
+      }
     };
 
     const voxaApp = new VoxaApp({ views, variables });
@@ -352,11 +352,11 @@ describe("VoxaApp", () => {
         alexaReply.fulfillIntent("YES");
         alexaReply.fulfillSlot("slot1", "YES", "YES");
         return alexaReply;
-      },
+      }
     );
 
     event = rb.getCanFulfillIntentRequestRequest("NameIntent", {
-      slot1: "something",
+      slot1: "something"
     });
     const reply = (await alexaSkill.execute(event)) as AlexaReply;
 
@@ -372,9 +372,9 @@ describe("VoxaApp", () => {
       slots: {
         slot1: {
           canFulfill: "YES",
-          canUnderstand: "YES",
-        },
-      },
+          canUnderstand: "YES"
+        }
+      }
     };
 
     const defaultFulfillIntents = ["NameIntent"];
@@ -382,7 +382,7 @@ describe("VoxaApp", () => {
     const alexaSkill = new AlexaPlatform(voxaApp, { defaultFulfillIntents });
 
     event = rb.getCanFulfillIntentRequestRequest("NameIntent", {
-      slot1: "something",
+      slot1: "something"
     });
     const reply = (await alexaSkill.execute(event)) as AlexaReply;
 
@@ -398,9 +398,9 @@ describe("VoxaApp", () => {
       slots: {
         slot1: {
           canFulfill: "YES",
-          canUnderstand: "YES",
-        },
-      },
+          canUnderstand: "YES"
+        }
+      }
     };
 
     const voxaApp = new VoxaApp({ views, variables });
@@ -410,11 +410,11 @@ describe("VoxaApp", () => {
         alexaReply.fulfillIntent("MAYBE");
         alexaReply.fulfillSlot("slot1", "YES", "YES");
         return alexaReply;
-      },
+      }
     );
 
     event = rb.getCanFulfillIntentRequestRequest("NameIntent", {
-      slot1: "something",
+      slot1: "something"
     });
     const reply = (await alexaSkill.execute(event)) as AlexaReply;
 
@@ -426,7 +426,7 @@ describe("VoxaApp", () => {
 
   it("should not fulfill request", async () => {
     const canFulfillIntent: canfulfill.CanFulfillIntent = {
-      canFulfill: "NO",
+      canFulfill: "NO"
     };
 
     const voxaApp = new VoxaApp({ views, variables });
@@ -435,11 +435,11 @@ describe("VoxaApp", () => {
       (alexaEvent: AlexaEvent, alexaReply: AlexaReply) => {
         alexaReply.fulfillIntent("NO");
         return alexaReply;
-      },
+      }
     );
 
     event = rb.getCanFulfillIntentRequestRequest("NameIntent", {
-      slot1: "something",
+      slot1: "something"
     });
     const reply = (await alexaSkill.execute(event)) as AlexaReply;
 
@@ -455,9 +455,9 @@ describe("VoxaApp", () => {
       slots: {
         slot1: {
           canFulfill: "NO",
-          canUnderstand: "NO",
-        },
-      },
+          canUnderstand: "NO"
+        }
+      }
     };
 
     const voxaApp = new VoxaApp({ views, variables });
@@ -467,11 +467,11 @@ describe("VoxaApp", () => {
         alexaReply.fulfillIntent("yes");
         alexaReply.fulfillSlot("slot1", "yes", "yes");
         return alexaReply;
-      },
+      }
     );
 
     event = rb.getCanFulfillIntentRequestRequest("NameIntent", {
-      slot1: "something",
+      slot1: "something"
     });
     const reply = (await alexaSkill.execute(event)) as AlexaReply;
 
@@ -490,11 +490,11 @@ describe("VoxaApp", () => {
       statesDefinition.LaunchIntent = simple.stub().resolveWith(null);
 
       _.map(statesDefinition, (state: any, name: string) =>
-        voxaApp.onState(name, state),
+        voxaApp.onState(name, state)
       );
       const reply = await platform.execute(launchEvent);
       expect(reply.speech).to.equal(
-        "<speak>An unrecoverable error occurred.</speak>",
+        "<speak>An unrecoverable error occurred.</speak>"
       );
     });
 
@@ -505,22 +505,22 @@ describe("VoxaApp", () => {
       const onUnhandledState = simple.stub().returnWith(
         Promise.resolve({
           flow: "terminate",
-          sayp: "Unhandled State",
-        }),
+          sayp: "Unhandled State"
+        })
       );
 
       voxaApp.onUnhandledState(onUnhandledState);
       voxaApp.onIntent("LaunchIntent", {
-        to: "otherState",
+        to: "otherState"
       });
 
       voxaApp.onState(
         "otherState",
         {
           flow: "terminate",
-          sayp: "Other State",
+          sayp: "Other State"
         },
-        "SomeIntent",
+        "SomeIntent"
       );
 
       const platform = new AlexaPlatform(voxaApp);
@@ -539,8 +539,8 @@ describe("VoxaApp", () => {
         const onUnhandledState = simple.stub().returnWith(
           Promise.resolve({
             tell: "ExitIntent.Farewell",
-            to: "die",
-          }),
+            to: "die"
+          })
         );
 
         voxaApp.onUnhandledState(onUnhandledState);
@@ -548,14 +548,14 @@ describe("VoxaApp", () => {
         statesDefinition.LaunchIntent = simple.stub().resolveWith(null);
 
         _.map(statesDefinition, (state: any, name: string) =>
-          voxaApp.onState(name, state),
+          voxaApp.onState(name, state)
         );
         const reply = await platform.execute(launchEvent);
         expect(onUnhandledState.called).to.be.true;
         expect(reply.speech).to.equal(
-          "<speak>Ok. For more info visit example.com site.</speak>",
+          "<speak>Ok. For more info visit example.com site.</speak>"
         );
-      },
+      }
     );
 
     it("should call onUnhandledState for intents without a handler", async () => {
@@ -565,8 +565,8 @@ describe("VoxaApp", () => {
       const onUnhandledState = simple.stub().returnWith(
         Promise.resolve({
           tell: "ExitIntent.Farewell",
-          to: "die",
-        }),
+          to: "die"
+        })
       );
 
       voxaApp.onUnhandledState(onUnhandledState);
@@ -574,12 +574,12 @@ describe("VoxaApp", () => {
       statesDefinition.LaunchIntent = simple.stub().resolveWith(null);
 
       _.map(statesDefinition, (state: any, name: string) =>
-        voxaApp.onState(name, state),
+        voxaApp.onState(name, state)
       );
       const reply = await platform.execute(launchEvent);
       expect(onUnhandledState.called).to.be.true;
       expect(reply.speech).to.equal(
-        "<speak>Ok. For more info visit example.com site.</speak>",
+        "<speak>Ok. For more info visit example.com site.</speak>"
       );
     });
   });
@@ -595,12 +595,12 @@ describe("VoxaApp", () => {
     voxaApp.onIntent("SomeIntent", () => ({
       directives,
       tell: "ExitIntent.Farewell",
-      to: "entry",
+      to: "entry"
     }));
 
     const reply = (await voxaApp.execute(
       alexaEvent,
-      new AlexaReply(),
+      new AlexaReply()
     )) as AlexaReply;
     expect(reply.response.directives).to.not.be.undefined;
     expect(reply.response.directives).to.have.length(1);
@@ -611,12 +611,12 @@ describe("VoxaApp", () => {
           stream: {
             offsetInMilliseconds: 0,
             token: "123",
-            url: "url",
-          },
+            url: "url"
+          }
         },
         playBehavior: "REPLACE_ALL",
-        type: "AudioPlayer.Play",
-      },
+        type: "AudioPlayer.Play"
+      }
     ]);
   });
 
@@ -630,12 +630,12 @@ describe("VoxaApp", () => {
 
     voxaApp.onIntent("SomeIntent", () => ({
       directives,
-      say: "ExitIntent.Farewell",
+      say: "ExitIntent.Farewell"
     }));
 
     const reply = (await voxaApp.execute(
       alexaEvent,
-      new AlexaReply(),
+      new AlexaReply()
     )) as AlexaReply;
     expect(reply.response.directives).to.not.be.undefined;
     expect(reply.response.directives).to.have.length(1);
@@ -646,12 +646,12 @@ describe("VoxaApp", () => {
           stream: {
             offsetInMilliseconds: 0,
             token: "123",
-            url: "url",
-          },
+            url: "url"
+          }
         },
         playBehavior: "REPLACE_ALL",
-        type: "AudioPlayer.Play",
-      },
+        type: "AudioPlayer.Play"
+      }
     ]);
   });
 
@@ -662,7 +662,7 @@ describe("VoxaApp", () => {
     const alexaEvent = launchEvent;
 
     statesDefinition.LaunchIntent = {
-      to: "fourthState",
+      to: "fourthState"
     };
 
     statesDefinition.fourthState = (request: IVoxaEvent) => {
@@ -676,7 +676,7 @@ describe("VoxaApp", () => {
     };
 
     _.map(statesDefinition, (state: any, name: string) =>
-      voxaApp.onState(name, state),
+      voxaApp.onState(name, state)
     );
     const reply = await platform.execute(alexaEvent);
     expect(reply.speech).to.deep.equal("<speak>0\n1</speak>");
@@ -688,7 +688,7 @@ describe("VoxaApp", () => {
     const alexaEvent = new AlexaEvent(event);
     alexaEvent.platform = platform;
     _.map(statesDefinition, (state: any, name: string) =>
-      voxaApp.onState(name, state),
+      voxaApp.onState(name, state)
     );
     const stubResponse = "STUB RESPONSE";
     const stub = simple.stub().resolveWith(stubResponse);
@@ -696,12 +696,12 @@ describe("VoxaApp", () => {
 
     const reply = (await voxaApp.execute(
       alexaEvent,
-      new AlexaReply(),
+      new AlexaReply()
     )) as AlexaReply;
     expect(stub.called).to.be.true;
     expect(reply).to.not.equal(stubResponse);
     expect(reply.speech).to.equal(
-      "<speak>Ok. For more info visit example.com site.</speak>",
+      "<speak>Ok. For more info visit example.com site.</speak>"
     );
   });
 
@@ -732,15 +732,15 @@ describe("VoxaApp", () => {
       voxaApp.onIntent("LaunchIntent", {
         flow: "yield",
         reply: "Reply.Say",
-        to: "entry",
+        to: "entry"
       });
       const response = (await voxaApp.execute(
         launchEvent,
-        new AlexaReply(),
+        new AlexaReply()
       )) as AlexaReply;
       expect(response.speech).to.deep.equal("<speak>this is a say</speak>");
       expect(response.reprompt).to.deep.equal(
-        "<speak>this is a reprompt</speak>",
+        "<speak>this is a reprompt</speak>"
       );
       expect(response.hasTerminated).to.be.false;
     });
@@ -752,31 +752,31 @@ describe("VoxaApp", () => {
         reply: "Reply.Card",
         reprompt: "Reprompt",
         say: "Say",
-        to: "entry",
+        to: "entry"
       });
       const alexaSkill = new AlexaPlatform(voxaApp);
       const response = await alexaSkill.execute(event);
 
       expect(_.get(response, "response.outputSpeech.ssml")).to.deep.equal(
-        "<speak>say</speak>",
+        "<speak>say</speak>"
       );
       expect(
-        _.get(response, "response.reprompt.outputSpeech.ssml"),
+        _.get(response, "response.reprompt.outputSpeech.ssml")
       ).to.deep.equal("<speak>reprompt</speak>");
       expect(response.response.card).to.deep.equal({
         image: {
           largeImageUrl: "https://example.com/large.jpg",
-          smallImageUrl: "https://example.com/small.jpg",
+          smallImageUrl: "https://example.com/small.jpg"
         },
         title: "Title",
-        type: "Standard",
+        type: "Standard"
       });
       expect(_.get(response, "response.directives[0]")).to.deep.equal({
         hint: {
           text: "this is the hint",
-          type: "PlainText",
+          type: "PlainText"
         },
-        type: "Hint",
+        type: "Hint"
       });
     });
   });

--- a/test/VoxaApp.spec.ts
+++ b/test/VoxaApp.spec.ts
@@ -22,7 +22,8 @@
 
 import "mocha";
 
-import { canfulfill, RequestEnvelope } from "ask-sdk-model";
+import { canfulfill } from '../src/platforms/alexa/CanFullfillintent';
+import { RequestEnvelope } from "ask-sdk-model";
 import { expect } from "chai";
 import * as _ from "lodash";
 import * as simple from "simple-mock";

--- a/test/VoxaApp.spec.ts
+++ b/test/VoxaApp.spec.ts
@@ -26,7 +26,7 @@ import { RequestEnvelope } from "ask-sdk-model";
 import { expect } from "chai";
 import * as _ from "lodash";
 import * as simple from "simple-mock";
-import { canfulfill } from "../src/platforms/alexa/CanFullfillintent";
+import * as canfulfill from "../src/platforms/alexa/CanFullfillintent";
 
 import {
   AlexaEvent,

--- a/test/VoxaApp.spec.ts
+++ b/test/VoxaApp.spec.ts
@@ -29,6 +29,7 @@ import * as simple from "simple-mock";
 import * as canfulfill from "../src/platforms/alexa/CanFullfillintent";
 
 import {
+  AlexaCanFullfillReply,
   AlexaEvent,
   AlexaPlatform,
   AlexaReply,
@@ -348,7 +349,7 @@ describe("VoxaApp", () => {
     const voxaApp = new VoxaApp({ views, variables });
     const alexaSkill = new AlexaPlatform(voxaApp);
     voxaApp.onCanFulfillIntentRequest(
-      (alexaEvent: AlexaEvent, alexaReply: AlexaReply) => {
+      (alexaEvent: AlexaEvent, alexaReply: AlexaCanFullfillReply) => {
         alexaReply.fulfillIntent("YES");
         alexaReply.fulfillSlot("slot1", "YES", "YES");
         return alexaReply;
@@ -358,7 +359,7 @@ describe("VoxaApp", () => {
     event = rb.getCanFulfillIntentRequestRequest("NameIntent", {
       slot1: "something",
     });
-    const reply = (await alexaSkill.execute(event)) as AlexaReply;
+    const reply = (await alexaSkill.execute(event)) as AlexaCanFullfillReply;
 
     expect(reply.response.card).to.be.undefined;
     expect(reply.response.reprompt).to.be.undefined;
@@ -384,7 +385,7 @@ describe("VoxaApp", () => {
     event = rb.getCanFulfillIntentRequestRequest("NameIntent", {
       slot1: "something",
     });
-    const reply = (await alexaSkill.execute(event)) as AlexaReply;
+    const reply = (await alexaSkill.execute(event)) as AlexaCanFullfillReply;
 
     expect(reply.response.card).to.be.undefined;
     expect(reply.response.reprompt).to.be.undefined;
@@ -406,7 +407,7 @@ describe("VoxaApp", () => {
     const voxaApp = new VoxaApp({ views, variables });
     const alexaSkill = new AlexaPlatform(voxaApp);
     voxaApp.onCanFulfillIntentRequest(
-      (alexaEvent: AlexaEvent, alexaReply: AlexaReply) => {
+      (alexaEvent: AlexaEvent, alexaReply: AlexaCanFullfillReply) => {
         alexaReply.fulfillIntent("MAYBE");
         alexaReply.fulfillSlot("slot1", "YES", "YES");
         return alexaReply;
@@ -416,7 +417,7 @@ describe("VoxaApp", () => {
     event = rb.getCanFulfillIntentRequestRequest("NameIntent", {
       slot1: "something",
     });
-    const reply = (await alexaSkill.execute(event)) as AlexaReply;
+    const reply = (await alexaSkill.execute(event)) as AlexaCanFullfillReply;
 
     expect(reply.response.card).to.be.undefined;
     expect(reply.response.reprompt).to.be.undefined;
@@ -432,7 +433,7 @@ describe("VoxaApp", () => {
     const voxaApp = new VoxaApp({ views, variables });
     const alexaSkill = new AlexaPlatform(voxaApp);
     voxaApp.onCanFulfillIntentRequest(
-      (alexaEvent: AlexaEvent, alexaReply: AlexaReply) => {
+      (alexaEvent: AlexaEvent, alexaReply: AlexaCanFullfillReply) => {
         alexaReply.fulfillIntent("NO");
         return alexaReply;
       },
@@ -441,7 +442,7 @@ describe("VoxaApp", () => {
     event = rb.getCanFulfillIntentRequestRequest("NameIntent", {
       slot1: "something",
     });
-    const reply = (await alexaSkill.execute(event)) as AlexaReply;
+    const reply = (await alexaSkill.execute(event)) as AlexaCanFullfillReply;
 
     expect(reply.response.card).to.be.undefined;
     expect(reply.response.reprompt).to.be.undefined;
@@ -463,7 +464,7 @@ describe("VoxaApp", () => {
     const voxaApp = new VoxaApp({ views, variables });
     const alexaSkill = new AlexaPlatform(voxaApp);
     voxaApp.onCanFulfillIntentRequest(
-      (alexaEvent: AlexaEvent, alexaReply: AlexaReply) => {
+      (alexaEvent: AlexaEvent, alexaReply: AlexaCanFullfillReply) => {
         alexaReply.fulfillIntent("yes");
         alexaReply.fulfillSlot("slot1", "yes", "yes");
         return alexaReply;
@@ -473,7 +474,7 @@ describe("VoxaApp", () => {
     event = rb.getCanFulfillIntentRequestRequest("NameIntent", {
       slot1: "something",
     });
-    const reply = (await alexaSkill.execute(event)) as AlexaReply;
+    const reply = (await alexaSkill.execute(event)) as AlexaCanFullfillReply;
 
     expect(reply.response.card).to.be.undefined;
     expect(reply.response.reprompt).to.be.undefined;

--- a/test/alexa/AlexaCanFullfillReply.spec.ts
+++ b/test/alexa/AlexaCanFullfillReply.spec.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2018 Rain Agency <contact@rain.agency>
+ * Author: Rain Agency <contact@rain.agency>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { expect } from "chai";
+import * as i18n from "i18next";
+import {
+  AlexaCanFullfillReply,
+  AlexaEvent,
+  AlexaPlatform,
+  Hint,
+  Renderer,
+  Tell,
+  VoxaApp,
+} from "../../src";
+import { AlexaRequestBuilder } from "../tools";
+import { variables } from "../variables";
+import { views } from "../views";
+
+const rb = new AlexaRequestBuilder();
+
+describe("AlexaCanFullfillReply", () => {
+  let reply: AlexaCanFullfillReply;
+  let event: AlexaEvent;
+  let renderer: Renderer;
+
+  before(() => {
+    i18n.init({
+      load: "all",
+      nonExplicitWhitelist: true,
+      resources: views,
+    });
+  });
+
+  beforeEach(() => {
+    const app = new VoxaApp({ views });
+    const skill = new AlexaPlatform(app);
+    renderer = new Renderer({ views, variables });
+    event = new AlexaEvent(rb.getIntentRequest("SomeIntent"));
+    event.renderer = renderer;
+    event.t = i18n.getFixedT(event.request.locale);
+    event.platform = skill;
+    reply = new AlexaCanFullfillReply();
+  });
+
+  it("should generate a correct alexa response for a CanFulfillIntentRequest", () => {
+    const canUnderstand = "YES";
+    const canFulfill = "YES";
+    const voxaEvent = new AlexaEvent(
+      rb.getCanFulfillIntentRequestRequest("test intent"),
+    );
+    reply = new AlexaCanFullfillReply();
+    reply.fulfillIntent("YES");
+    reply.fulfillSlot("slot1", canUnderstand, canFulfill);
+
+    expect(JSON.parse(JSON.stringify(reply))).to.deep.equal({
+      response: {
+        canFulfillIntent: {
+          canFulfill: "YES",
+          slots: {
+            slot1: {
+              canFulfill: "YES",
+              canUnderstand: "YES",
+            },
+          },
+        },
+      },
+      sessionAttributes: {},
+      version: "1.0",
+    });
+  });
+});

--- a/test/alexa/AlexaReply.spec.ts
+++ b/test/alexa/AlexaReply.spec.ts
@@ -29,7 +29,7 @@ import {
   Hint,
   Renderer,
   Tell,
-  VoxaApp
+  VoxaApp,
 } from "../../src";
 import { AlexaRequestBuilder } from "../tools";
 import { variables } from "../variables";
@@ -46,7 +46,7 @@ describe("AlexaReply", () => {
     i18n.init({
       load: "all",
       nonExplicitWhitelist: true,
-      resources: views
+      resources: views,
     });
   });
 
@@ -70,18 +70,18 @@ describe("AlexaReply", () => {
         // card: undefined,
         outputSpeech: {
           ssml: "<speak>ask</speak>",
-          type: "SSML"
+          type: "SSML",
         },
         reprompt: {
           outputSpeech: {
             ssml: "<speak>reprompt</speak>",
-            type: "SSML"
-          }
+            type: "SSML",
+          },
         },
-        shouldEndSession: false
+        shouldEndSession: false,
       },
       sessionAttributes: {},
-      version: "1.0"
+      version: "1.0",
     });
   });
 
@@ -91,12 +91,12 @@ describe("AlexaReply", () => {
       response: {
         outputSpeech: {
           ssml: "<speak>ask</speak>",
-          type: "SSML"
+          type: "SSML",
         },
-        shouldEndSession: false
+        shouldEndSession: false,
       },
       sessionAttributes: {},
-      version: "1.0"
+      version: "1.0",
     });
   });
 
@@ -107,12 +107,12 @@ describe("AlexaReply", () => {
       response: {
         outputSpeech: {
           ssml: "<speak>tell</speak>",
-          type: "SSML"
+          type: "SSML",
         },
-        shouldEndSession: true
+        shouldEndSession: true,
       },
       sessionAttributes: {},
-      version: "1.0"
+      version: "1.0",
     });
   });
 
@@ -150,7 +150,7 @@ describe("AlexaReply", () => {
     const canUnderstand = "YES";
     const canFulfill = "YES";
     const voxaEvent = new AlexaEvent(
-      rb.getCanFulfillIntentRequestRequest("test intent")
+      rb.getCanFulfillIntentRequestRequest("test intent"),
     );
     reply = new AlexaReply(voxaEvent);
     reply.fulfillIntent("YES");
@@ -163,13 +163,13 @@ describe("AlexaReply", () => {
           slots: {
             slot1: {
               canFulfill: "YES",
-              canUnderstand: "YES"
-            }
-          }
-        }
+              canUnderstand: "YES",
+            },
+          },
+        },
       },
       sessionAttributes: {},
-      version: "1.0"
+      version: "1.0",
     });
   });
 
@@ -183,16 +183,16 @@ describe("AlexaReply", () => {
       response: {
         outputSpeech: {
           ssml: "<speak>tell</speak>",
-          type: "SSML"
+          type: "SSML",
         },
-        shouldEndSession: true
+        shouldEndSession: true,
       },
       sessionAttributes: {
         model: {
-          name: "name"
-        }
+          name: "name",
+        },
       },
-      version: "1.0"
+      version: "1.0",
     });
   });
 
@@ -206,19 +206,19 @@ describe("AlexaReply", () => {
           {
             hint: {
               text: "string",
-              type: "PlainText"
+              type: "PlainText",
             },
-            type: "Hint"
-          }
+            type: "Hint",
+          },
         ],
         outputSpeech: {
           ssml: "<speak>Ok. For more info visit example.com site.</speak>",
-          type: "SSML"
+          type: "SSML",
         },
-        shouldEndSession: true
+        shouldEndSession: true,
       },
       sessionAttributes: {},
-      version: "1.0"
+      version: "1.0",
     });
   });
 });

--- a/test/alexa/AlexaReply.spec.ts
+++ b/test/alexa/AlexaReply.spec.ts
@@ -149,8 +149,8 @@ describe("AlexaReply", () => {
   it("should generate a correct alexa response for a CanFulfillIntentRequest", () => {
     const canUnderstand = "YES";
     const canFulfill = "YES";
-
-    reply = new AlexaReply();
+    const voxaEvent = new AlexaEvent(rb.getCanFulfillIntentRequestRequest('test intent'));
+    reply = new AlexaReply(voxaEvent);
     reply.fulfillIntent("YES");
     reply.fulfillSlot("slot1", canUnderstand, canFulfill);
 

--- a/test/alexa/AlexaReply.spec.ts
+++ b/test/alexa/AlexaReply.spec.ts
@@ -29,7 +29,7 @@ import {
   Hint,
   Renderer,
   Tell,
-  VoxaApp,
+  VoxaApp
 } from "../../src";
 import { AlexaRequestBuilder } from "../tools";
 import { variables } from "../variables";
@@ -46,7 +46,7 @@ describe("AlexaReply", () => {
     i18n.init({
       load: "all",
       nonExplicitWhitelist: true,
-      resources: views,
+      resources: views
     });
   });
 
@@ -70,18 +70,18 @@ describe("AlexaReply", () => {
         // card: undefined,
         outputSpeech: {
           ssml: "<speak>ask</speak>",
-          type: "SSML",
+          type: "SSML"
         },
         reprompt: {
           outputSpeech: {
             ssml: "<speak>reprompt</speak>",
-            type: "SSML",
-          },
+            type: "SSML"
+          }
         },
-        shouldEndSession: false,
+        shouldEndSession: false
       },
       sessionAttributes: {},
-      version: "1.0",
+      version: "1.0"
     });
   });
 
@@ -91,12 +91,12 @@ describe("AlexaReply", () => {
       response: {
         outputSpeech: {
           ssml: "<speak>ask</speak>",
-          type: "SSML",
+          type: "SSML"
         },
-        shouldEndSession: false,
+        shouldEndSession: false
       },
       sessionAttributes: {},
-      version: "1.0",
+      version: "1.0"
     });
   });
 
@@ -107,12 +107,12 @@ describe("AlexaReply", () => {
       response: {
         outputSpeech: {
           ssml: "<speak>tell</speak>",
-          type: "SSML",
+          type: "SSML"
         },
-        shouldEndSession: true,
+        shouldEndSession: true
       },
       sessionAttributes: {},
-      version: "1.0",
+      version: "1.0"
     });
   });
 
@@ -149,7 +149,9 @@ describe("AlexaReply", () => {
   it("should generate a correct alexa response for a CanFulfillIntentRequest", () => {
     const canUnderstand = "YES";
     const canFulfill = "YES";
-    const voxaEvent = new AlexaEvent(rb.getCanFulfillIntentRequestRequest('test intent'));
+    const voxaEvent = new AlexaEvent(
+      rb.getCanFulfillIntentRequestRequest("test intent")
+    );
     reply = new AlexaReply(voxaEvent);
     reply.fulfillIntent("YES");
     reply.fulfillSlot("slot1", canUnderstand, canFulfill);
@@ -161,13 +163,13 @@ describe("AlexaReply", () => {
           slots: {
             slot1: {
               canFulfill: "YES",
-              canUnderstand: "YES",
-            },
-          },
-        },
+              canUnderstand: "YES"
+            }
+          }
+        }
       },
       sessionAttributes: {},
-      version: "1.0",
+      version: "1.0"
     });
   });
 
@@ -181,16 +183,16 @@ describe("AlexaReply", () => {
       response: {
         outputSpeech: {
           ssml: "<speak>tell</speak>",
-          type: "SSML",
+          type: "SSML"
         },
-        shouldEndSession: true,
+        shouldEndSession: true
       },
       sessionAttributes: {
         model: {
-          name: "name",
-        },
+          name: "name"
+        }
       },
-      version: "1.0",
+      version: "1.0"
     });
   });
 
@@ -204,19 +206,19 @@ describe("AlexaReply", () => {
           {
             hint: {
               text: "string",
-              type: "PlainText",
+              type: "PlainText"
             },
-            type: "Hint",
-          },
+            type: "Hint"
+          }
         ],
         outputSpeech: {
           ssml: "<speak>Ok. For more info visit example.com site.</speak>",
-          type: "SSML",
+          type: "SSML"
         },
-        shouldEndSession: true,
+        shouldEndSession: true
       },
       sessionAttributes: {},
-      version: "1.0",
+      version: "1.0"
     });
   });
 });

--- a/test/alexa/AlexaReply.spec.ts
+++ b/test/alexa/AlexaReply.spec.ts
@@ -146,33 +146,6 @@ describe("AlexaReply", () => {
   // });
   // });
 
-  it("should generate a correct alexa response for a CanFulfillIntentRequest", () => {
-    const canUnderstand = "YES";
-    const canFulfill = "YES";
-    const voxaEvent = new AlexaEvent(
-      rb.getCanFulfillIntentRequestRequest("test intent"),
-    );
-    reply = new AlexaReply(voxaEvent);
-    reply.fulfillIntent("YES");
-    reply.fulfillSlot("slot1", canUnderstand, canFulfill);
-
-    expect(JSON.parse(JSON.stringify(reply))).to.deep.equal({
-      response: {
-        canFulfillIntent: {
-          canFulfill: "YES",
-          slots: {
-            slot1: {
-              canFulfill: "YES",
-              canUnderstand: "YES",
-            },
-          },
-        },
-      },
-      sessionAttributes: {},
-      version: "1.0",
-    });
-  });
-
   it("should generate a correct alexa response persisting session attributes", () => {
     reply = new AlexaReply();
     reply.addStatement("tell");

--- a/test/tools.ts
+++ b/test/tools.ts
@@ -3,12 +3,12 @@ import {
   interfaces,
   RequestEnvelope,
   Session,
-  SessionEndedReason
+  SessionEndedReason,
 } from "ask-sdk-model";
 import {
   APIGatewayProxyEvent,
   Callback as AWSLambdaCallback,
-  Context as AWSLambdaContext
+  Context as AWSLambdaContext,
 } from "aws-lambda";
 import * as _ from "lodash";
 import { v1 } from "uuid";
@@ -29,7 +29,7 @@ export class AlexaRequestBuilder {
 
   public getSessionEndedRequest(
     reason: SessionEndedReason = "ERROR",
-    error?: any
+    error?: any,
   ): RequestEnvelope {
     return {
       context: this.getContextData(),
@@ -39,10 +39,10 @@ export class AlexaRequestBuilder {
         reason,
         requestId: `EdwRequestId.${v1()}`,
         timestamp: new Date().toISOString(),
-        type: "SessionEndedRequest"
+        type: "SessionEndedRequest",
       },
       session: this.getSessionData(),
-      version: this.version
+      version: this.version,
     };
   }
 
@@ -54,23 +54,23 @@ export class AlexaRequestBuilder {
         requestId: `EdwRequestId.${v1()}`,
         timestamp: new Date().toISOString(),
         token,
-        type: "Display.ElementSelected"
+        type: "Display.ElementSelected",
       },
       session: this.getSessionData(),
-      version: this.version
+      version: this.version,
     };
   }
 
   public getCanFulfillIntentRequestRequest(
     intentName: string,
-    slots?: any
+    slots?: any,
   ): any {
     if (!slots) {
       slots = {};
     } else {
       slots = _(slots)
         .keys()
-        .map(key => [key, { name: key, value: slots[key] }])
+        .map((key) => [key, { name: key, value: slots[key] }])
         .fromPairs()
         .value();
     }
@@ -82,10 +82,10 @@ export class AlexaRequestBuilder {
         locale: "en-US",
         requestId: `EdwRequestId.${v1()}`,
         timestamp: new Date().toISOString(),
-        type: "CanFulfillIntentRequest"
+        type: "CanFulfillIntentRequest",
       },
       session: this.getSessionData(),
-      version: this.version
+      version: this.version,
     };
   }
 
@@ -95,7 +95,7 @@ export class AlexaRequestBuilder {
     } else {
       slots = _(slots)
         .keys()
-        .map(key => [key, { name: key, value: slots[key] }])
+        .map((key) => [key, { name: key, value: slots[key] }])
         .fromPairs()
         .value();
     }
@@ -108,17 +108,17 @@ export class AlexaRequestBuilder {
         locale: "en-US",
         requestId: `EdwRequestId.${v1()}`,
         timestamp: new Date().toISOString(),
-        type: "IntentRequest"
+        type: "IntentRequest",
       },
       session: this.getSessionData(),
-      version: this.version
+      version: this.version,
     };
   }
 
   public getContextData(): Context {
     return {
       AudioPlayer: {
-        playerActivity: "IDLE"
+        playerActivity: "IDLE",
       },
       System: {
         apiAccessToken: v1(),
@@ -128,16 +128,16 @@ export class AlexaRequestBuilder {
           deviceId: this.deviceId,
           supportedInterfaces: {
             AudioPlayer: {},
-            Display: {}
-          }
+            Display: {},
+          },
         },
         user: {
           permissions: {
-            consentToken: v1()
+            consentToken: v1(),
           },
-          userId: this.userId
-        }
-      }
+          userId: this.userId,
+        },
+      },
     };
   }
   public getSessionData(newSession: boolean = true): Session {
@@ -149,10 +149,10 @@ export class AlexaRequestBuilder {
       sessionId: `SessionId.${v1()}`,
       user: {
         permissions: {
-          consentToken: ""
+          consentToken: "",
         },
-        userId: this.userId
-      }
+        userId: this.userId,
+      },
     };
   }
 
@@ -163,10 +163,10 @@ export class AlexaRequestBuilder {
         locale: "en-US",
         requestId: "EdwRequestId." + v1(),
         timestamp: new Date().toISOString(),
-        type: "LaunchRequest"
+        type: "LaunchRequest",
       },
       session: this.getSessionData(),
-      version: this.version
+      version: this.version,
     };
   }
 
@@ -176,32 +176,32 @@ export class AlexaRequestBuilder {
       requestId: "EdwRequestId." + v1(),
       timestamp: new Date().toISOString(),
       token,
-      type: "AudioPlayer.PlaybackStopped"
+      type: "AudioPlayer.PlaybackStopped",
     };
 
     return {
       context: this.getContextData(),
       request,
       session: this.getSessionData(),
-      version: this.version
+      version: this.version,
     };
   }
 
   public getGameEngineInputHandlerEventRequest(
-    buttonsRecognized: number = 1
+    buttonsRecognized: number = 1,
   ): RequestEnvelope {
     const request: interfaces.gameEngine.InputHandlerEventRequest = {
       events: [],
       locale: "en-US",
       requestId: `amzn1.echo-api.request.${v1()}`,
       timestamp: new Date().toISOString(),
-      type: "GameEngine.InputHandlerEvent"
+      type: "GameEngine.InputHandlerEvent",
     };
 
     const eventArray: any[] = [];
     eventArray.push({
       inputEvents: [],
-      name: "sample_event"
+      name: "sample_event",
     });
 
     let id = 1;
@@ -212,7 +212,7 @@ export class AlexaRequestBuilder {
         color: "000000",
         feature: "press",
         gadgetId: `id${id}`,
-        timestamp: "timestamp"
+        timestamp: "timestamp",
       };
 
       id += 1;
@@ -226,7 +226,7 @@ export class AlexaRequestBuilder {
       context: this.getContextData(),
       request,
       session: this.getSessionData(false),
-      version: this.version
+      version: this.version,
     };
   }
 
@@ -234,7 +234,7 @@ export class AlexaRequestBuilder {
     name: string,
     token: string,
     payload: any,
-    status?: interfaces.connections.ConnectionsStatus
+    status?: interfaces.connections.ConnectionsStatus,
   ): RequestEnvelope {
     status = status || { code: "200", message: "OK" };
 
@@ -246,20 +246,20 @@ export class AlexaRequestBuilder {
       status,
       timestamp: new Date().toISOString(),
       token,
-      type: "Connections.Response"
+      type: "Connections.Response",
     };
 
     return {
       context: this.getContextData(),
       request,
       session: this.getSessionData(false),
-      version: this.version
+      version: this.version,
     };
   }
 }
 
 export function getLambdaContext(
-  callback: AWSLambdaCallback<any>
+  callback: AWSLambdaCallback<any>,
 ): AWSLambdaContext {
   return {
     awsRequestId: "aws://",
@@ -281,13 +281,13 @@ export function getLambdaContext(
 
       return callback(err);
     },
-    succeed: (msg: any) => callback(undefined, msg)
+    succeed: (msg: any) => callback(undefined, msg),
   };
 }
 
 export function getAPIGatewayProxyEvent(
   method: string = "GET",
-  body: string | null = null
+  body: string | null = null,
 ): APIGatewayProxyEvent {
   return {
     body,
@@ -314,17 +314,17 @@ export function getAPIGatewayProxyEvent(
         sourceIp: "",
         user: null,
         userAgent: null,
-        userArn: null
+        userArn: null,
       },
       path: "/",
       requestId: "",
       requestTimeEpoch: 123,
       resourceId: "",
       resourcePath: "/",
-      stage: ""
+      stage: "",
     },
     resource: "",
-    stageVariables: null
+    stageVariables: null,
   };
 }
 

--- a/test/tools.ts
+++ b/test/tools.ts
@@ -64,7 +64,7 @@ export class AlexaRequestBuilder {
   public getCanFulfillIntentRequestRequest(
     intentName: string,
     slots?: any,
-  ): RequestEnvelope {
+  ): any {
     if (!slots) {
       slots = {};
     } else {

--- a/test/tools.ts
+++ b/test/tools.ts
@@ -3,12 +3,12 @@ import {
   interfaces,
   RequestEnvelope,
   Session,
-  SessionEndedReason,
+  SessionEndedReason
 } from "ask-sdk-model";
 import {
   APIGatewayProxyEvent,
   Callback as AWSLambdaCallback,
-  Context as AWSLambdaContext,
+  Context as AWSLambdaContext
 } from "aws-lambda";
 import * as _ from "lodash";
 import { v1 } from "uuid";
@@ -29,7 +29,7 @@ export class AlexaRequestBuilder {
 
   public getSessionEndedRequest(
     reason: SessionEndedReason = "ERROR",
-    error?: any,
+    error?: any
   ): RequestEnvelope {
     return {
       context: this.getContextData(),
@@ -39,10 +39,10 @@ export class AlexaRequestBuilder {
         reason,
         requestId: `EdwRequestId.${v1()}`,
         timestamp: new Date().toISOString(),
-        type: "SessionEndedRequest",
+        type: "SessionEndedRequest"
       },
       session: this.getSessionData(),
-      version: this.version,
+      version: this.version
     };
   }
 
@@ -54,23 +54,23 @@ export class AlexaRequestBuilder {
         requestId: `EdwRequestId.${v1()}`,
         timestamp: new Date().toISOString(),
         token,
-        type: "Display.ElementSelected",
+        type: "Display.ElementSelected"
       },
       session: this.getSessionData(),
-      version: this.version,
+      version: this.version
     };
   }
 
   public getCanFulfillIntentRequestRequest(
     intentName: string,
-    slots?: any,
+    slots?: any
   ): any {
     if (!slots) {
       slots = {};
     } else {
       slots = _(slots)
         .keys()
-        .map((key) => [key, { name: key, value: slots[key] }])
+        .map(key => [key, { name: key, value: slots[key] }])
         .fromPairs()
         .value();
     }
@@ -82,10 +82,10 @@ export class AlexaRequestBuilder {
         locale: "en-US",
         requestId: `EdwRequestId.${v1()}`,
         timestamp: new Date().toISOString(),
-        type: "CanFulfillIntentRequest",
+        type: "CanFulfillIntentRequest"
       },
       session: this.getSessionData(),
-      version: this.version,
+      version: this.version
     };
   }
 
@@ -95,7 +95,7 @@ export class AlexaRequestBuilder {
     } else {
       slots = _(slots)
         .keys()
-        .map((key) => [key, { name: key, value: slots[key] }])
+        .map(key => [key, { name: key, value: slots[key] }])
         .fromPairs()
         .value();
     }
@@ -108,17 +108,17 @@ export class AlexaRequestBuilder {
         locale: "en-US",
         requestId: `EdwRequestId.${v1()}`,
         timestamp: new Date().toISOString(),
-        type: "IntentRequest",
+        type: "IntentRequest"
       },
       session: this.getSessionData(),
-      version: this.version,
+      version: this.version
     };
   }
 
   public getContextData(): Context {
     return {
       AudioPlayer: {
-        playerActivity: "IDLE",
+        playerActivity: "IDLE"
       },
       System: {
         apiAccessToken: v1(),
@@ -128,16 +128,16 @@ export class AlexaRequestBuilder {
           deviceId: this.deviceId,
           supportedInterfaces: {
             AudioPlayer: {},
-            Display: {},
-          },
+            Display: {}
+          }
         },
         user: {
           permissions: {
-            consentToken: v1(),
+            consentToken: v1()
           },
-          userId: this.userId,
-        },
-      },
+          userId: this.userId
+        }
+      }
     };
   }
   public getSessionData(newSession: boolean = true): Session {
@@ -149,10 +149,10 @@ export class AlexaRequestBuilder {
       sessionId: `SessionId.${v1()}`,
       user: {
         permissions: {
-          consentToken: "",
+          consentToken: ""
         },
-        userId: this.userId,
-      },
+        userId: this.userId
+      }
     };
   }
 
@@ -163,10 +163,10 @@ export class AlexaRequestBuilder {
         locale: "en-US",
         requestId: "EdwRequestId." + v1(),
         timestamp: new Date().toISOString(),
-        type: "LaunchRequest",
+        type: "LaunchRequest"
       },
       session: this.getSessionData(),
-      version: this.version,
+      version: this.version
     };
   }
 
@@ -176,32 +176,32 @@ export class AlexaRequestBuilder {
       requestId: "EdwRequestId." + v1(),
       timestamp: new Date().toISOString(),
       token,
-      type: "AudioPlayer.PlaybackStopped",
+      type: "AudioPlayer.PlaybackStopped"
     };
 
     return {
       context: this.getContextData(),
       request,
       session: this.getSessionData(),
-      version: this.version,
+      version: this.version
     };
   }
 
   public getGameEngineInputHandlerEventRequest(
-    buttonsRecognized: number = 1,
+    buttonsRecognized: number = 1
   ): RequestEnvelope {
     const request: interfaces.gameEngine.InputHandlerEventRequest = {
       events: [],
       locale: "en-US",
       requestId: `amzn1.echo-api.request.${v1()}`,
       timestamp: new Date().toISOString(),
-      type: "GameEngine.InputHandlerEvent",
+      type: "GameEngine.InputHandlerEvent"
     };
 
     const eventArray: any[] = [];
     eventArray.push({
       inputEvents: [],
-      name: "sample_event",
+      name: "sample_event"
     });
 
     let id = 1;
@@ -212,7 +212,7 @@ export class AlexaRequestBuilder {
         color: "000000",
         feature: "press",
         gadgetId: `id${id}`,
-        timestamp: "timestamp",
+        timestamp: "timestamp"
       };
 
       id += 1;
@@ -226,7 +226,7 @@ export class AlexaRequestBuilder {
       context: this.getContextData(),
       request,
       session: this.getSessionData(false),
-      version: this.version,
+      version: this.version
     };
   }
 
@@ -234,7 +234,7 @@ export class AlexaRequestBuilder {
     name: string,
     token: string,
     payload: any,
-    status?: interfaces.connections.ConnectionsStatus,
+    status?: interfaces.connections.ConnectionsStatus
   ): RequestEnvelope {
     status = status || { code: "200", message: "OK" };
 
@@ -246,20 +246,20 @@ export class AlexaRequestBuilder {
       status,
       timestamp: new Date().toISOString(),
       token,
-      type: "Connections.Response",
+      type: "Connections.Response"
     };
 
     return {
       context: this.getContextData(),
       request,
       session: this.getSessionData(false),
-      version: this.version,
+      version: this.version
     };
   }
 }
 
 export function getLambdaContext(
-  callback: AWSLambdaCallback<any>,
+  callback: AWSLambdaCallback<any>
 ): AWSLambdaContext {
   return {
     awsRequestId: "aws://",
@@ -281,13 +281,13 @@ export function getLambdaContext(
 
       return callback(err);
     },
-    succeed: (msg: any) => callback(undefined, msg),
+    succeed: (msg: any) => callback(undefined, msg)
   };
 }
 
 export function getAPIGatewayProxyEvent(
   method: string = "GET",
-  body: string | null = null,
+  body: string | null = null
 ): APIGatewayProxyEvent {
   return {
     body,
@@ -314,17 +314,17 @@ export function getAPIGatewayProxyEvent(
         sourceIp: "",
         user: null,
         userAgent: null,
-        userArn: null,
+        userArn: null
       },
       path: "/",
       requestId: "",
       requestTimeEpoch: 123,
       resourceId: "",
       resourcePath: "/",
-      stage: "",
+      stage: ""
     },
     resource: "",
-    stageVariables: null,
+    stageVariables: null
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,27 +5,22 @@
 "@types/async@^2.0.48":
   version "2.0.49"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.49.tgz#92e33d13f74c895cb9a7f38ba97db8431ed14bc0"
-  integrity sha512-Benr3i5odUkvpFkOpzGqrltGdbSs+EVCkEBGXbuR7uT0VzhXKIkhem6PDzHdx5EonA+rfbB3QvP6aDOw5+zp5Q==
 
 "@types/aws-lambda@^0.0.33":
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-0.0.33.tgz#17083d9c569048792f4f33ef6cd6aaf54d5b22d3"
-  integrity sha512-p13MzAb/1ZJK1h0jDhRjdFqlRHC44HAOS7qYuVpn7NnFDv8UdNbRjExfhK69syvI9IoIR4NN4dRGjpVDsN6tEQ==
 
 "@types/aws-lambda@^8.10.6":
   version "8.10.13"
   resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.13.tgz#92cc06b1cc88b5d0b327d2671dcf3daea96923a5"
-  integrity sha512-a1sC60Bqll4N2RYnd4+XuynrVd8LO+uZrgwCVaAER0ldMQ00LRM4iTjU2ulPoQF6P5bHZK5hL/6IF9088VJhUA==
 
 "@types/bluebird@*", "@types/bluebird@^3.5.18":
   version "3.5.24"
   resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.24.tgz#11f76812531c14f793b8ecbf1de96f672905de8a"
-  integrity sha512-YeQoDpq4Lm8ppSBqAnAeF/xy1cYp/dMTif2JFcvmAbETMRlvKHT2iLcWu+WyYiJO3b3Ivokwo7EQca/xfLVJmg==
 
 "@types/body-parser@*":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.0.tgz#9f5c9d9bd04bb54be32d5eb9fc0d8c974e6cf58c"
-  integrity sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==
   dependencies:
     "@types/connect" "*"
     "@types/node" "*"
@@ -33,46 +28,38 @@
 "@types/caseless@*":
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.1.tgz#9794c69c8385d0192acc471a540d1f8e0d16218a"
-  integrity sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A==
 
 "@types/chai-as-promised@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.0.tgz#010b04cde78eacfb6e72bfddb3e58fe23c2e78b9"
-  integrity sha512-MFiW54UOSt+f2bRw8J7LgQeIvE/9b4oGvwU7XW30S9QGAiHGnU/fmiOprsyMkdmH2rl8xSPc0/yrQw8juXU6bQ==
   dependencies:
     "@types/chai" "*"
 
 "@types/chai@*":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.4.tgz#5ca073b330d90b4066d6ce18f60d57f2084ce8ca"
-  integrity sha512-h6+VEw2Vr3ORiFCyyJmcho2zALnUq9cvdB/IO8Xs9itrJVCenC7o26A6+m7D0ihTTr65eS259H5/Ghl/VjYs6g==
 
 "@types/chai@^4.0.10":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.6.tgz#1eb26c040e3a84205b1008ad55c800e5e8a94e34"
-  integrity sha512-CBk7KTZt3FhPsEkYioG6kuCIpWISw+YI8o+3op4+NXwTpvAPxE1ES8+PY8zfaK2L98b1z5oq03UHa4VYpeUxnw==
 
 "@types/connect@*":
   version "3.4.32"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.32.tgz#aa0e9616b9435ccad02bc52b5b454ffc2c70ba28"
-  integrity sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==
   dependencies:
     "@types/node" "*"
 
 "@types/debug@^0.0.30":
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.30.tgz#dc1e40f7af3b9c815013a7860e6252f6352a84df"
-  integrity sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==
 
 "@types/events@*":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
-  integrity sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==
 
 "@types/express-serve-static-core@*":
   version "4.16.0"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.16.0.tgz#fdfe777594ddc1fe8eb8eccce52e261b496e43e7"
-  integrity sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==
   dependencies:
     "@types/events" "*"
     "@types/node" "*"
@@ -81,7 +68,6 @@
 "@types/express@^4.11.1":
   version "4.16.0"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.16.0.tgz#6d8bc42ccaa6f35cf29a2b7c3333cb47b5a32a19"
-  integrity sha512-TtPEYumsmSTtTetAPXlJVf3kEqb6wZK0bZojpJQrnD/djV4q1oB6QQ8aKvKqwNPACoe02GNiy5zDzcYivR5Z2w==
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "*"
@@ -90,21 +76,18 @@
 "@types/form-data@*", "@types/form-data@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-2.2.1.tgz#ee2b3b8eaa11c0938289953606b745b738c54b1e"
-  integrity sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==
   dependencies:
     "@types/node" "*"
 
 "@types/fs-extra@5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.0.1.tgz#cd856fbbdd6af2c11f26f8928fd8644c9e9616c9"
-  integrity sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==
   dependencies:
     "@types/node" "*"
 
 "@types/glob@*":
   version "5.0.35"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-5.0.35.tgz#1ae151c802cece940443b5ac246925c85189f32a"
-  integrity sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==
   dependencies:
     "@types/events" "*"
     "@types/minimatch" "*"
@@ -113,29 +96,24 @@
 "@types/handlebars@4.0.36":
   version "4.0.36"
   resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.36.tgz#ff57c77fa1ab6713bb446534ddc4d979707a3a79"
-  integrity sha512-LjNiTX7TY7wtuC6y3QwC93hKMuqYhgV9A1uXBKNvZtVC8ZvyWAjZkJ5BvT0K7RKqORRYRLMrqCxpw5RgS+MdrQ==
 
 "@types/highlight.js@9.12.2":
   version "9.12.2"
   resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.2.tgz#6ee7cd395effe5ec80b515d3ff1699068cd0cd1d"
-  integrity sha512-y5x0XD/WXDaGSyiTaTcKS4FurULJtSiYbGTeQd0m2LYZGBcZZ/7fM6t5H/DzeUF+kv8y6UfmF6yJABQsHcp9VQ==
 
 "@types/i18next@^8.4.2":
   version "8.4.6"
   resolved "https://registry.yarnpkg.com/@types/i18next/-/i18next-8.4.6.tgz#d03e36289c913dc624378f5f1c8925e553e6d6c8"
-  integrity sha512-ZiSCqW8j9/gQCYixz1nMhyCprSGh3rwdyX+FHAzEN+bMCmc7yCYjNutl6jvMYSxSIGeL0CLEXPM8Nlk2lE0t5w==
 
 "@types/jsonwebtoken@^7.2.6":
   version "7.2.7"
   resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-7.2.7.tgz#5dd62e0c0a0c6f211c3c1d13d322360894625b47"
-  integrity sha512-lq9X76APpxGJDUe1VptL1P5GrogqhPCH+SDy94+gaBJw7Hhj6hwrVC6zuxAx2GrgktkBuwydESZBvPfrdBoOEg==
   dependencies:
     "@types/node" "*"
 
 "@types/lambda-log@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/lambda-log/-/lambda-log-2.0.1.tgz#dfd3eecbb18bd7d229ab444ba1f97b9bd7e5bd1d"
-  integrity sha512-cb8rYFwiXfQ1Dj/Icdyg440CDzw32Ewb4Dr6DHaOHzDXoSEiYVHT1aclcqj4qswUzGuTL7xZdtRtwNuQovP4cA==
   dependencies:
     "@types/events" "*"
     "@types/node" "*"
@@ -143,69 +121,56 @@
 "@types/lodash@4.14.104":
   version "4.14.104"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.104.tgz#53ee2357fa2e6e68379341d92eb2ecea4b11bb80"
-  integrity sha512-ufQcVg4daO8xQ5kopxRHanqFdL4AI7ondQkV+2f+7mz3gvp0LkBx2zBRC6hfs3T87mzQFmf5Fck7Fi145Ul6NQ==
 
 "@types/lodash@^4.14.88":
   version "4.14.116"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
-  integrity sha512-lRnAtKnxMXcYYXqOiotTmJd74uawNWuPnsnPrrO7HiFuE3npE2iQhfABatbYDyxTNqZNuXzcKGhw37R7RjBFLg==
 
 "@types/marked@0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.3.0.tgz#583c223dd33385a1dda01aaf77b0cd0411c4b524"
-  integrity sha512-CSf9YWJdX1DkTNu9zcNtdCcn6hkRtB5ILjbhRId4ZOQqx30fXmdecuaXhugQL6eyrhuXtaHJ7PHI+Vm7k9ZJjg==
 
 "@types/mime@*":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
-  integrity sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==
 
 "@types/minimatch@*", "@types/minimatch@3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
-  integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/mocha@^2.2.45":
   version "2.2.48"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.48.tgz#3523b126a0b049482e1c3c11877460f76622ffab"
-  integrity sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==
 
 "@types/nock@^9.3.0":
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@types/nock/-/nock-9.3.0.tgz#9d34358fdcc08afd07144e0784ac9e951d412dd4"
-  integrity sha512-ZHf/X8rTQ5Tb1rHjxIJYqm55uO265agE3G7NoSXVa2ep+EcJXgB2fsme+zBvK7MhrxTwkC/xkB6THyv50u0MGw==
   dependencies:
     "@types/node" "*"
 
 "@types/node@*":
   version "10.11.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.3.tgz#c055536ac8a5e871701aa01914be5731539d01ee"
-  integrity sha512-3AvcEJAh9EMatxs+OxAlvAEs7OTy6AG94mcH1iqyVDwVVndekLxzwkWQ/Z4SDbY6GO2oyUXyWW8tQ4rENSSQVQ==
 
 "@types/node@^8.0.58":
   version "8.10.32"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.32.tgz#f8df7c32975e36e1215d22ae5f087752931c1e4a"
-  integrity sha512-8OfXpkB3E0jhpcpyVlqJDV5mkXlrsJrDZR7q0uss8SBdW8IxNdx/J2o5m7cM2qbFzyd/o+aV5Z4OJcIukI6UlA==
 
 "@types/node@^9.4.6":
   version "9.6.31"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.31.tgz#4d1722987f8d808b4c194dceb8c213bd92f028e5"
-  integrity sha512-kIVlvUBizL51ALNMPbmcZoM7quHyB7J6fLRwQe22JsMp39nrVSHdBeVVS3fnQCK1orxI3O8LScmb8cuiihkAfA==
 
 "@types/node@^9.6.1":
   version "9.6.20"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.20.tgz#b59a1bd357ae2df7d44d5ac98e9b64eb96ea1fef"
-  integrity sha512-mIMXUbH2MmJAQQjzFUIRpxa+FtA27IaHMrIgoJ1fyu/EfpVN/UZw3ISMNnwVec4lau8R8SM4pNFXSCZpJFX2Bw==
 
 "@types/range-parser@*":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.2.tgz#fa8e1ad1d474688a757140c91de6dace6f4abc8d"
-  integrity sha512-HtKGu+qG1NPvYe1z7ezLsyIaXYyi8SoAVqWDZgDQ8dLrsZvSzUNCwZyfX33uhWxL/SU0ZDQZ3nwZ0nimt507Kw==
 
 "@types/request-promise@^4.1.39":
   version "4.1.42"
   resolved "https://registry.yarnpkg.com/@types/request-promise/-/request-promise-4.1.42.tgz#a70a6777429531e60ed09faa077ead9b995204cd"
-  integrity sha512-b8li55sEZ00BXZstZ3d8WOi48dnapTqB1VufEG9Qox0nVI2JVnTVT1Mw4JbBa1j+1sGVX/qJ0R4WDv4v2GjT0w==
   dependencies:
     "@types/bluebird" "*"
     "@types/request" "*"
@@ -213,7 +178,6 @@
 "@types/request@*":
   version "2.47.1"
   resolved "https://registry.yarnpkg.com/@types/request/-/request-2.47.1.tgz#25410d3afbdac04c91a94ad9efc9824100735824"
-  integrity sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==
   dependencies:
     "@types/caseless" "*"
     "@types/form-data" "*"
@@ -223,7 +187,6 @@
 "@types/request@^2.47.0":
   version "2.47.0"
   resolved "https://registry.yarnpkg.com/@types/request/-/request-2.47.0.tgz#76a666cee4cb85dcffea6cd4645227926d9e114e"
-  integrity sha512-/KXM5oev+nNCLIgBjkwbk8VqxmzI56woD4VUxn95O+YeQ8hJzcSmIZ1IN3WexiqBb6srzDo2bdMbsXxgXNkz5Q==
   dependencies:
     "@types/caseless" "*"
     "@types/form-data" "*"
@@ -233,7 +196,6 @@
 "@types/serve-static@*":
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.2.tgz#f5ac4d7a6420a99a6a45af4719f4dcd8cd907a48"
-  integrity sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
@@ -241,7 +203,6 @@
 "@types/shelljs@0.7.8":
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.8.tgz#4b4d6ee7926e58d7bca448a50ba442fd9f6715bd"
-  integrity sha512-M2giRw93PxKS7YjU6GZjtdV9HASdB7TWqizBXe4Ju7AqbKlWvTr0gNO92XH56D/gMxqD/jNHLNfC5hA34yGqrQ==
   dependencies:
     "@types/glob" "*"
     "@types/node" "*"
@@ -249,27 +210,22 @@
 "@types/simple-mock@^0.0.27":
   version "0.0.27"
   resolved "https://registry.yarnpkg.com/@types/simple-mock/-/simple-mock-0.0.27.tgz#a9f58db60b5c09c66156467346ff069f8d66352a"
-  integrity sha1-qfWNtgtcCcZhVkZzRv8Gn41mNSo=
 
 "@types/sprintf-js@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/sprintf-js/-/sprintf-js-1.1.0.tgz#6850a98382b517c4a4d0401c63f2b0be76cee092"
-  integrity sha512-AQSq0X2Pj+2UbLIAxRmnj7Tll4btd1fj3hFf0XxB3/ZT7qjQ2WA3/JKtehu8UXEbkNCcysG6ZnYs58F1e/FboA==
 
 "@types/strip-bom@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/strip-bom/-/strip-bom-3.0.0.tgz#14a8ec3956c2e81edb7520790aecf21c290aebd2"
-  integrity sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=
 
 "@types/strip-json-comments@0.0.30":
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
-  integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
 
 "@types/tedious@^1.8.32":
   version "1.8.33"
   resolved "https://registry.yarnpkg.com/@types/tedious/-/tedious-1.8.33.tgz#eb53a6815c1887fe720668d733698ec5ec2749e8"
-  integrity sha512-G/UocgY+xu+Ab51pz/xuXxUnMLxfmY6o6GSmOu/q9M8yGK/g3CTk+4cGEhUaB/dLlP0dQ/J1OZC3XB6XqneXiQ==
   dependencies:
     "@types/events" "*"
     "@types/node" "*"
@@ -277,24 +233,20 @@
 "@types/tough-cookie@*":
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-2.3.3.tgz#7f226d67d654ec9070e755f46daebf014628e9d9"
-  integrity sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ==
 
 "@types/url-join@^0.8.1", "@types/url-join@^0.8.2":
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@types/url-join/-/url-join-0.8.2.tgz#1181ecbe1d97b7034e0ea1e35e62e86cc26b422d"
-  integrity sha1-EYHsvh2XtwNODqHjXmLobMJrQi0=
 
 "@types/uuid@^3.4.1", "@types/uuid@^3.4.3":
   version "3.4.4"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.4.tgz#7af69360fa65ef0decb41fd150bf4ca5c0cefdf5"
-  integrity sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==
   dependencies:
     "@types/node" "*"
 
 actions-on-google@2:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/actions-on-google/-/actions-on-google-2.3.0.tgz#4da4f104f1af99b08e065811bdb5e9f8ed6db31d"
-  integrity sha512-RF+AD0f+h+13XO2BxXHF0fNSCxE6pZFZqQ1bFeabUY/XdZSHyQjQjpkJqudiHCQWjct86a95+YhltTNqxASbMQ==
   dependencies:
     "@types/aws-lambda" "^0.0.33"
     "@types/debug" "^0.0.30"
@@ -307,7 +259,6 @@ actions-on-google@2:
 ajv@^5.1.0, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
-  integrity sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -317,7 +268,6 @@ ajv@^5.1.0, ajv@^5.3.0:
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
-  integrity sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=
   dependencies:
     kind-of "^3.0.2"
     longest "^1.0.1"
@@ -326,125 +276,102 @@ align-text@^0.1.1, align-text@^0.1.3:
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
-  integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
-  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
 
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
-  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
 
 append-transform@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
-  integrity sha1-126/jKlNJ24keja61EpLdKthGZE=
   dependencies:
     default-require-extensions "^1.0.0"
 
 archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
-  integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
 
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
-  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
 
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
-  integrity sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=
 
 arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
-  integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
 
 arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
-  integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
 array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
-  integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
 arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
-  integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
 asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
 
-ask-sdk-model@1.4.0-beta.1:
-  version "1.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/ask-sdk-model/-/ask-sdk-model-1.4.0-beta.1.tgz#d45a3758f95f4de7f2643a2db6002fb01ca58a71"
-  integrity sha512-oAPD4xIlE5T2QAsCaj6v1FEkztrF8qRDnABqsyfArkEeWA6JEmSonrwxG5kEHVwnu/46QAwlJiemnRtoJ8933g==
+ask-sdk-model@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/ask-sdk-model/-/ask-sdk-model-1.8.0.tgz#458b3ec9df5bd71af2e55033d3c798e6a56f7197"
 
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
-  integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
   dependencies:
     safer-buffer "~2.1.0"
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
-  integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
 assertion-error@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
-  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
-  integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
 async@^1.4.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
 atob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
-  integrity sha1-ri1acpR38onWDdf5amMUoi3Wwio=
 
 aws-sdk@^2.246.1:
   version "2.318.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.318.0.tgz#b9e8e795d4ae9d5ba428cdaa75dde49acce708d4"
-  integrity sha512-w2XT+DOKOczoRaB9R0cRCZSwHkw4JfngMlUKeRhMbzOvW9orOZB2SeMgz+Pz1jKU3VSJDMpvB/Z3P68nvDxb8Q==
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -459,17 +386,14 @@ aws-sdk@^2.246.1:
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
-  integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
 aws4@^1.6.0, aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
-  integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
 axios@^0.18.0:
   version "0.18.0"
   resolved "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
-  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
   dependencies:
     follow-redirects "^1.3.0"
     is-buffer "^1.1.5"
@@ -477,12 +401,10 @@ axios@^0.18.0:
 azure-functions-ts-essentials@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/azure-functions-ts-essentials/-/azure-functions-ts-essentials-1.3.2.tgz#a0917842ef700125411289e0c5c2f04e0d961d7c"
-  integrity sha512-DdeXyzAbx632bwNs/+xp6meXWHvKpHCC2647Trfzs48QtEgsxEUB+0Jz4W5J4SNs4k640lWE6431ITOuPsSgpQ==
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
-  integrity sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
   dependencies:
     chalk "^1.1.3"
     esutils "^2.0.2"
@@ -491,7 +413,6 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
 babel-generator@^6.18.0:
   version "6.26.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
-  integrity sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==
   dependencies:
     babel-messages "^6.23.0"
     babel-runtime "^6.26.0"
@@ -505,14 +426,12 @@ babel-generator@^6.18.0:
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
-  integrity sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=
   dependencies:
     babel-runtime "^6.22.0"
 
 babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
@@ -520,7 +439,6 @@ babel-runtime@^6.22.0, babel-runtime@^6.26.0:
 babel-template@^6.16.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
-  integrity sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=
   dependencies:
     babel-runtime "^6.26.0"
     babel-traverse "^6.26.0"
@@ -531,7 +449,6 @@ babel-template@^6.16.0:
 babel-traverse@^6.18.0, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
-  integrity sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=
   dependencies:
     babel-code-frame "^6.26.0"
     babel-messages "^6.23.0"
@@ -546,7 +463,6 @@ babel-traverse@^6.18.0, babel-traverse@^6.26.0:
 babel-types@^6.18.0, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
-  integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
   dependencies:
     babel-runtime "^6.26.0"
     esutils "^2.0.2"
@@ -556,27 +472,22 @@ babel-types@^6.18.0, babel-types@^6.26.0:
 babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
-  integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
 base64-js@^1.0.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
-  integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
 
 base64url@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/base64url/-/base64url-2.0.0.tgz#eac16e03ea1438eff9423d69baa36262ed1f70bb"
-  integrity sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs=
 
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
-  integrity sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==
   dependencies:
     cache-base "^1.0.1"
     class-utils "^0.3.5"
@@ -589,24 +500,20 @@ base@^0.11.1:
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
-  integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
 
 bluebird@^3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
-  integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
 
 bluebird@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
-  integrity sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==
 
 botbuilder@^3.13.1:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/botbuilder/-/botbuilder-3.15.0.tgz#394e7abd35a0781c0365df62ee953fcedfa6d50c"
-  integrity sha512-KH5GTskHvTSozRPLdn8EQtg34zc71VUo+wXYzcoafRCkGVqqxB4AitUqow8y8ENiHgJW3oY2Pvhd8glcZiraOA==
   dependencies:
     "@types/async" "^2.0.48"
     "@types/express" "^4.11.1"
@@ -629,7 +536,6 @@ botbuilder@^3.13.1:
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -637,7 +543,6 @@ brace-expansion@^1.1.7:
 braces@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
-  integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
   dependencies:
     arr-flatten "^1.1.0"
     array-unique "^0.3.2"
@@ -653,22 +558,18 @@ braces@^2.3.1:
 browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
-  integrity sha1-81HTKWnTL6XXpVZxVCY9korjvR8=
 
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
-  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
 
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
-  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
 buffer@4.9.1:
   version "4.9.1"
   resolved "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
-  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -677,12 +578,10 @@ buffer@4.9.1:
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
-  integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
 
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
-  integrity sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==
   dependencies:
     collection-visit "^1.0.0"
     component-emitter "^1.2.1"
@@ -697,7 +596,6 @@ cache-base@^1.0.1:
 caching-transform@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/caching-transform/-/caching-transform-1.0.1.tgz#6dbdb2f20f8d8fbce79f3e94e9d1742dcdf5c0a1"
-  integrity sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=
   dependencies:
     md5-hex "^1.2.0"
     mkdirp "^0.5.1"
@@ -706,22 +604,18 @@ caching-transform@^1.0.0:
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
-  integrity sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=
 
 camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
-  integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-  integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
 center-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
-  integrity sha1-qg0yYptu6XIgBBHL1EYckHvCt60=
   dependencies:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
@@ -729,14 +623,12 @@ center-align@^0.1.1:
 chai-as-promised@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
-  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
   dependencies:
     check-error "^1.0.2"
 
 chai@^4.1.2:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
-  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
   dependencies:
     assertion-error "^1.1.0"
     check-error "^1.0.2"
@@ -748,7 +640,6 @@ chai@^4.1.2:
 chalk@^1.1.3:
   version "1.1.3"
   resolved "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
-  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
   dependencies:
     ansi-styles "^2.2.1"
     escape-string-regexp "^1.0.2"
@@ -759,7 +650,6 @@ chalk@^1.1.3:
 chalk@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
-  integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -768,19 +658,16 @@ chalk@^2.3.0:
 check-error@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
-  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 chrono-node@^1.1.3:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/chrono-node/-/chrono-node-1.3.5.tgz#a2495298a32da82bcc01ad9be7d77efa5e244122"
-  integrity sha1-oklSmKMtqCvMAa2b59d++l4kQSI=
   dependencies:
     moment "^2.10.3"
 
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
-  integrity sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
   dependencies:
     arr-union "^3.1.0"
     define-property "^0.2.5"
@@ -790,7 +677,6 @@ class-utils@^0.3.5:
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
-  integrity sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=
   dependencies:
     center-align "^0.1.1"
     right-align "^0.1.1"
@@ -799,7 +685,6 @@ cliui@^2.1.0:
 cliui@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
-  integrity sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
@@ -808,17 +693,14 @@ cliui@^4.0.0:
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
-  integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
-  integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
-  integrity sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=
   dependencies:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
@@ -826,78 +708,64 @@ collection-visit@^1.0.0:
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
-  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
   dependencies:
     color-name "1.1.3"
 
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 combined-stream@1.0.6, combined-stream@~1.0.5, combined-stream@~1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
-  integrity sha1-cj599ugBrFYTETp+RFqbactjKBg=
   dependencies:
     delayed-stream "~1.0.0"
 
 commander@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
-  integrity sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==
 
 commander@2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
-  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
   dependencies:
     graceful-readlink ">= 1.0.0"
 
 commander@^2.12.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
-  integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
-  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
 component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
-  integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
 
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
 convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
-  integrity sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
-  integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js@^2.4.0:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
-  integrity sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==
 
 core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-  integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
 coveralls@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.2.tgz#f5a0bcd90ca4e64e088b710fa8dda640aea4884f"
-  integrity sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==
   dependencies:
     growl "~> 1.10.0"
     js-yaml "^3.11.0"
@@ -909,7 +777,6 @@ coveralls@^3.0.1:
 cross-spawn@^4:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
-  integrity sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=
   dependencies:
     lru-cache "^4.0.1"
     which "^1.2.9"
@@ -917,7 +784,6 @@ cross-spawn@^4:
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
-  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
   dependencies:
     lru-cache "^4.0.1"
     shebang-command "^1.2.0"
@@ -926,83 +792,70 @@ cross-spawn@^5.0.1:
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
-  integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
   dependencies:
     assert-plus "^1.0.0"
 
 debug-log@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
-  integrity sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=
 
 debug@2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
-  integrity sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=
   dependencies:
     ms "2.0.0"
 
 debug@3.1.0, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 
 debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
 
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
-  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
-  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
 deep-eql@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
-  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
   dependencies:
     type-detect "^4.0.0"
 
 deep-equal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
-  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
 
 default-require-extensions@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
-  integrity sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=
   dependencies:
     strip-bom "^2.0.0"
 
 define-property@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
-  integrity sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=
   dependencies:
     is-descriptor "^0.1.0"
 
 define-property@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
-  integrity sha1-dp66rz9KY6rTr56NMEybvnm/sOY=
   dependencies:
     is-descriptor "^1.0.0"
 
 define-property@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
-  integrity sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
@@ -1010,39 +863,32 @@ define-property@^2.0.2:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
-  integrity sha1-920GQ1LN9Docts5hnE7jqUdd4gg=
   dependencies:
     repeating "^2.0.0"
 
 diff@1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.0.7.tgz#24bbb001c4a7d5522169e7cabdb2c2814ed91cf4"
-  integrity sha1-JLuwAcSn1VIhaefKvbLCgU7ZHPQ=
 
 diff@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
-  integrity sha1-yc45Okt8vQsFinJck98pkCeGj/k=
 
 diff@3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
-  integrity sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==
 
 diff@^3.1.0, diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
-  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
-  integrity sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
@@ -1050,41 +896,34 @@ ecc-jsbn@~0.1.1:
 ecdsa-sig-formatter@1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz#1c595000f04a8897dfb85000892a0f4c33af86c3"
-  integrity sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=
   dependencies:
     safe-buffer "^5.0.1"
 
 error-ex@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
-  integrity sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=
   dependencies:
     is-arrayish "^0.2.1"
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
-  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
-  integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
 events@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
-  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
-  integrity sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
@@ -1097,7 +936,6 @@ execa@^0.7.0:
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
-  integrity sha1-t3c14xXOMPa27/D4OwQVGiJEliI=
   dependencies:
     debug "^2.3.3"
     define-property "^0.2.5"
@@ -1110,14 +948,12 @@ expand-brackets@^2.1.4:
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
-  integrity sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=
   dependencies:
     is-extendable "^0.1.0"
 
 extend-shallow@^3.0.0, extend-shallow@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
-  integrity sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=
   dependencies:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
@@ -1125,12 +961,10 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
 extend@^3.0.1, extend@~3.0.1, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
-  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
-  integrity sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==
   dependencies:
     array-unique "^0.3.2"
     define-property "^1.0.0"
@@ -1144,27 +978,22 @@ extglob@^2.0.4:
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-  integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
 
 extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
-  integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
 fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
-  integrity sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
-  integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
-  integrity sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=
   dependencies:
     extend-shallow "^2.0.1"
     is-number "^3.0.0"
@@ -1174,7 +1003,6 @@ fill-range@^4.0.0:
 find-cache-dir@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-0.1.1.tgz#c8defae57c8a52a8a784f9e31c57c742e993a0b9"
-  integrity sha1-yN765XyKUqinhPnjHFfHQumToLk=
   dependencies:
     commondir "^1.0.1"
     mkdirp "^0.5.1"
@@ -1183,7 +1011,6 @@ find-cache-dir@^0.1.1:
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
-  integrity sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=
   dependencies:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
@@ -1191,26 +1018,22 @@ find-up@^1.0.0:
 find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
-  integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
 
 follow-redirects@^1.3.0:
   version "1.5.7"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.7.tgz#a39e4804dacb90202bca76a9e2ac10433ca6a69a"
-  integrity sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==
   dependencies:
     debug "^3.1.0"
 
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
-  integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
 
 foreground-child@^1.5.3, foreground-child@^1.5.6:
   version "1.5.6"
   resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-1.5.6.tgz#4fd71ad2dfde96789b980a5c0a295937cb2f5ce9"
-  integrity sha1-T9ca0t/elnibmApcCilZN8svXOk=
   dependencies:
     cross-spawn "^4"
     signal-exit "^3.0.0"
@@ -1218,12 +1041,10 @@ foreground-child@^1.5.3, foreground-child@^1.5.6:
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
-  integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
 form-data@~2.3.1, form-data@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
-  integrity sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=
   dependencies:
     asynckit "^0.4.0"
     combined-stream "1.0.6"
@@ -1232,14 +1053,12 @@ form-data@~2.3.1, form-data@~2.3.2:
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
-  integrity sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
   dependencies:
     map-cache "^0.2.2"
 
 fs-extra@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
-  integrity sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -1248,12 +1067,10 @@ fs-extra@^5.0.0:
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
-  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 gcp-metadata@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-0.6.3.tgz#4550c08859c528b370459bd77a7187ea0bdbc4ab"
-  integrity sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==
   dependencies:
     axios "^0.18.0"
     extend "^3.0.1"
@@ -1262,34 +1079,28 @@ gcp-metadata@^0.6.3:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
-  integrity sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=
 
 get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
-  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
-  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
-  integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
-  integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
 
 glob@7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
-  integrity sha1-gFIR3wT6rxxjo2ADBs31reULLsg=
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1301,7 +1112,6 @@ glob@7.1.1:
 glob@7.1.2, glob@^7.0.0, glob@^7.0.5, glob@^7.0.6:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
-  integrity sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1313,7 +1123,6 @@ glob@7.1.2, glob@^7.0.0, glob@^7.0.5, glob@^7.0.6:
 glob@^7.1.1:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
-  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1325,12 +1134,10 @@ glob@^7.1.1:
 globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
-  integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
 
 google-auth-library@^1.3.1, google-auth-library@^1.3.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-1.6.1.tgz#9c73d831ad720c0c3048ab89d0ffdec714d07dd2"
-  integrity sha512-jYiWC8NA9n9OtQM7ANn0Tk464do9yhKEtaJ72pKcaBiEwn4LwcGYIYOfwtfsSm3aur/ed3tlSxbmg24IAT6gAg==
   dependencies:
     axios "^0.18.0"
     gcp-metadata "^0.6.3"
@@ -1343,7 +1150,6 @@ google-auth-library@^1.3.1, google-auth-library@^1.3.2:
 google-p12-pem@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-1.0.2.tgz#c8a3843504012283a0dbffc7430b7c753ecd4b07"
-  integrity sha512-+EuKr4CLlGsnXx4XIJIVkcKYrsa2xkAmCvxRhX2HsazJzUBAJ35wARGeApHUn4nNfPD03Vl057FskNr20VaCyg==
   dependencies:
     node-forge "^0.7.4"
     pify "^3.0.0"
@@ -1351,7 +1157,6 @@ google-p12-pem@^1.0.0:
 googleapis@^27.0.0:
   version "27.0.0"
   resolved "https://registry.yarnpkg.com/googleapis/-/googleapis-27.0.0.tgz#c210633b43e7047b65d33da40c489b6d8f9c02b8"
-  integrity sha512-Cz0BRsZmewc21N50x5nAUW5cqaGhJ9ETQKZMGqGL4BxmCV7ETELazSqmNi4oCDeRwM4Iub/fIJWAWZk2i6XLCg==
   dependencies:
     google-auth-library "^1.3.1"
     pify "^3.0.0"
@@ -1362,32 +1167,26 @@ googleapis@^27.0.0:
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-  integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
-  integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
 growl@1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
-  integrity sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==
 
 growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
-  integrity sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=
 
 "growl@~> 1.10.0":
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
-  integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
 gtoken@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-2.3.0.tgz#4e0ffc16432d7041a1b3dbc1d97aac17a5dc964a"
-  integrity sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==
   dependencies:
     axios "^0.18.0"
     google-p12-pem "^1.0.0"
@@ -1398,7 +1197,6 @@ gtoken@^2.3.0:
 handlebars@^4.0.3, handlebars@^4.0.6:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
-  integrity sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=
   dependencies:
     async "^1.4.0"
     optimist "^0.6.1"
@@ -1409,12 +1207,10 @@ handlebars@^4.0.3, handlebars@^4.0.6:
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-  integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
 har-validator@~5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
-  integrity sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=
   dependencies:
     ajv "^5.1.0"
     har-schema "^2.0.0"
@@ -1422,7 +1218,6 @@ har-validator@~5.0.3:
 har-validator@~5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.0.tgz#44657f5688a22cfd4b72486e81b3a3fb11742c29"
-  integrity sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==
   dependencies:
     ajv "^5.3.0"
     har-schema "^2.0.0"
@@ -1430,29 +1225,24 @@ har-validator@~5.1.0:
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
-  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
   dependencies:
     ansi-regex "^2.0.0"
 
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
-  integrity sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=
 
 has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
-  integrity sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=
 
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
 has-value@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
-  integrity sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=
   dependencies:
     get-value "^2.0.3"
     has-values "^0.1.4"
@@ -1461,7 +1251,6 @@ has-value@^0.3.1:
 has-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
-  integrity sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=
   dependencies:
     get-value "^2.0.6"
     has-values "^1.0.0"
@@ -1470,12 +1259,10 @@ has-value@^1.0.0:
 has-values@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
-  integrity sha1-bWHeldkd/Km5oCCJrThL/49it3E=
 
 has-values@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
-  integrity sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
@@ -1483,34 +1270,28 @@ has-values@^1.0.0:
 he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
-  integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
 
 highlight.js@^9.0.0:
   version "9.12.0"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
-  integrity sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=
 
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
-  integrity sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=
 
 homedir-polyfill@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
-  integrity sha1-TCu8inWJmP7r9e1oWA921GdotLw=
   dependencies:
     parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.0.tgz#23235b29ab230c576aab0d4f13fc046b0b038222"
-  integrity sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==
 
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
-  integrity sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
   dependencies:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
@@ -1519,27 +1300,22 @@ http-signature@~1.2.0:
 i18next@^9.0.1:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-9.1.0.tgz#408005fe262a990c8d93946a6de0c77bba11667b"
-  integrity sha512-oarlBl8AX+2xSae45aT57y/i0dlhRP+MAYhuV2AMtih4Cv+ICpAApOILxtxi0BKPL95FMDStIH4F0PX/4CwfCQ==
 
 ieee754@1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
-  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
 
 ieee754@^1.1.4:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
-  integrity sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==
 
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
-  integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
-  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
   dependencies:
     once "^1.3.0"
     wrappy "1"
@@ -1547,74 +1323,62 @@ inflight@^1.0.4:
 inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
-  integrity sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=
 
 invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
 
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
-  integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
-  integrity sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=
   dependencies:
     kind-of "^3.0.2"
 
 is-accessor-descriptor@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
-  integrity sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==
   dependencies:
     kind-of "^6.0.0"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
-  integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
-  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-builtin-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
-  integrity sha1-VAVy0096wxGfj3bDDLwbHgN6/74=
   dependencies:
     builtin-modules "^1.0.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
-  integrity sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=
   dependencies:
     kind-of "^3.0.2"
 
 is-data-descriptor@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
-  integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
   dependencies:
     kind-of "^6.0.0"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
-  integrity sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==
   dependencies:
     is-accessor-descriptor "^0.1.6"
     is-data-descriptor "^0.1.4"
@@ -1623,7 +1387,6 @@ is-descriptor@^0.1.0:
 is-descriptor@^1.0.0, is-descriptor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
-  integrity sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==
   dependencies:
     is-accessor-descriptor "^1.0.0"
     is-data-descriptor "^1.0.0"
@@ -1632,128 +1395,106 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
-  integrity sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=
 
 is-extendable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
-  integrity sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
   dependencies:
     is-plain-object "^2.0.4"
 
 is-finite@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
-  integrity sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=
   dependencies:
     number-is-nan "^1.0.0"
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
-  integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
   dependencies:
     number-is-nan "^1.0.0"
 
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-  integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
-  integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   dependencies:
     kind-of "^3.0.2"
 
 is-number@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
-  integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
 
 is-odd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-2.0.0.tgz#7646624671fd7ea558ccd9a2795182f2958f1b24"
-  integrity sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==
   dependencies:
     is-number "^4.0.0"
 
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
-  integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
 
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
-  integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
-  integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
-  integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
 isarray@1.0.0, isarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
 isemail@1.x.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/isemail/-/isemail-1.2.0.tgz#be03df8cc3e29de4d2c5df6501263f1fa4595e9a"
-  integrity sha1-vgPfjMPineTSxd9lASY/H6RZXpo=
 
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
-  integrity sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=
   dependencies:
     isarray "1.0.0"
 
 isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
-  integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
-  integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
 istanbul-lib-coverage@^1.1.2, istanbul-lib-coverage@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
-  integrity sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==
 
 istanbul-lib-hook@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz#8538d970372cb3716d53e55523dd54b557a8d89b"
-  integrity sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==
   dependencies:
     append-transform "^0.4.0"
 
 istanbul-lib-instrument@^1.10.0:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
-  integrity sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==
   dependencies:
     babel-generator "^6.18.0"
     babel-template "^6.16.0"
@@ -1766,7 +1507,6 @@ istanbul-lib-instrument@^1.10.0:
 istanbul-lib-report@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz#2df12188c0fa77990c0d2176d2d0ba3394188259"
-  integrity sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==
   dependencies:
     istanbul-lib-coverage "^1.1.2"
     mkdirp "^0.5.1"
@@ -1776,7 +1516,6 @@ istanbul-lib-report@^1.1.3:
 istanbul-lib-source-maps@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz#20fb54b14e14b3fb6edb6aca3571fd2143db44e6"
-  integrity sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==
   dependencies:
     debug "^3.1.0"
     istanbul-lib-coverage "^1.1.2"
@@ -1787,19 +1526,16 @@ istanbul-lib-source-maps@^1.2.3:
 istanbul-reports@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.4.1.tgz#4f2e8e928aa7a05d1da6c427d4098b2655ec7334"
-  integrity sha512-mwOHJ7jDof5IgKYIB5pbLA/gEE9nyjQwqUQbyonu+/Tuc4g1nMHNTdmFhbhqIVBagTryAUprZaYoC08OB0sXCA==
   dependencies:
     handlebars "^4.0.3"
 
 jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
-  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 joi@^6.10.1:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/joi/-/joi-6.10.1.tgz#4d50c318079122000fe5f16af1ff8e1917b77e06"
-  integrity sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=
   dependencies:
     hoek "2.x.x"
     isemail "1.x.x"
@@ -1809,12 +1545,10 @@ joi@^6.10.1:
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
-  integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
 js-yaml@^3.11.0, js-yaml@^3.7.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
-  integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -1822,44 +1556,36 @@ js-yaml@^3.11.0, js-yaml@^3.7.0:
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
-  integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
-  integrity sha1-RsP+yMGJKxKwgz25vHYiF226s0s=
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
-  integrity sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=
 
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
 json3@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
-  integrity sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=
 
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   optionalDependencies:
     graceful-fs "^4.1.6"
 
 jsonwebtoken@^7.0.1:
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz#77f5021de058b605a1783fa1283e99812e645638"
-  integrity sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=
   dependencies:
     joi "^6.10.1"
     jws "^3.1.4"
@@ -1870,7 +1596,6 @@ jsonwebtoken@^7.0.1:
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
-  integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
   dependencies:
     assert-plus "1.0.0"
     extsprintf "1.3.0"
@@ -1880,7 +1605,6 @@ jsprim@^1.2.2:
 jwa@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.1.6.tgz#87240e76c9808dbde18783cf2264ef4929ee50e6"
-  integrity sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==
   dependencies:
     buffer-equal-constant-time "1.0.1"
     ecdsa-sig-formatter "1.0.10"
@@ -1889,7 +1613,6 @@ jwa@^1.1.5:
 jws@^3.1.4, jws@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/jws/-/jws-3.1.5.tgz#80d12d05b293d1e841e7cb8b4e69e561adcf834f"
-  integrity sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==
   dependencies:
     jwa "^1.1.5"
     safe-buffer "^5.0.1"
@@ -1897,55 +1620,46 @@ jws@^3.1.4, jws@^3.1.5:
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
-  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
   dependencies:
     is-buffer "^1.1.5"
 
 kind-of@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
-  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
   dependencies:
     is-buffer "^1.1.5"
 
 kind-of@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
-  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
 
 kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
-  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
 lambda-log@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lambda-log/-/lambda-log-2.0.0.tgz#8a5a89d6ef0ededd95a1b08351783c410ff2806d"
-  integrity sha512-Zbk6td4GbBC1vA2o3KOFfTv+rTD4am6w6PPGCDfEGqEtDkvUKwDwMRgLeoOCMsBLvPoOfmr9tf5wHNJtKOuVeQ==
   dependencies:
     json-stringify-safe "^5.0.1"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
-  integrity sha1-odePw6UEdMuAhF07O24dpJpEbo4=
 
 lcid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
-  integrity sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=
   dependencies:
     invert-kv "^1.0.0"
 
 lcov-parse@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
-  integrity sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=
 
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
-  integrity sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=
   dependencies:
     graceful-fs "^4.1.2"
     parse-json "^2.2.0"
@@ -1956,7 +1670,6 @@ load-json-file@^1.0.0:
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
-  integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
   dependencies:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
@@ -1964,7 +1677,6 @@ locate-path@^2.0.0:
 lodash._baseassign@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
-  integrity sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=
   dependencies:
     lodash._basecopy "^3.0.0"
     lodash.keys "^3.0.0"
@@ -1972,27 +1684,22 @@ lodash._baseassign@^3.0.0:
 lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
-  integrity sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=
 
 lodash._basecreate@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
-  integrity sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=
 
 lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
-  integrity sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=
 
 lodash.create@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
-  integrity sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=
   dependencies:
     lodash._baseassign "^3.0.0"
     lodash._basecreate "^3.0.0"
@@ -2001,22 +1708,18 @@ lodash.create@3.1.1:
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
-  integrity sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=
 
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
-  integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
 
 lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
-  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
 lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
-  integrity sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=
   dependencies:
     lodash._getnative "^3.0.0"
     lodash.isarguments "^3.0.0"
@@ -2025,39 +1728,32 @@ lodash.keys@^3.0.0:
 lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
-  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash@^4.13.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
 
 log-driver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
-  integrity sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==
 
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
-  integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
 
 loose-envify@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
-  integrity sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=
   dependencies:
     js-tokens "^3.0.0"
 
 lru-cache@^4.0.1, lru-cache@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
-  integrity sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
@@ -2065,55 +1761,46 @@ lru-cache@^4.0.1, lru-cache@^4.1.3:
 make-error@^1.1.1:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.4.tgz#19978ed575f9e9545d2ff8c13e33b5d18a67d535"
-  integrity sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==
 
 map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
-  integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
 
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
-  integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
 
 marked@^0.3.17:
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
-  integrity sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==
 
 md5-hex@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/md5-hex/-/md5-hex-1.3.0.tgz#d2c4afe983c4370662179b8cad145219135046c4"
-  integrity sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=
   dependencies:
     md5-o-matic "^0.1.1"
 
 md5-o-matic@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
-  integrity sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=
 
 mem@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
-  integrity sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
   dependencies:
     mimic-fn "^1.0.0"
 
 merge-source-map@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
-  integrity sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==
   dependencies:
     source-map "^0.6.1"
 
 micromatch@^3.1.10, micromatch@^3.1.8:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
-  integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
   dependencies:
     arr-diff "^4.0.0"
     array-unique "^0.3.2"
@@ -2132,51 +1819,42 @@ micromatch@^3.1.10, micromatch@^3.1.8:
 mime-db@~1.36.0:
   version "1.36.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
-  integrity sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==
 
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19:
   version "2.1.20"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.20.tgz#930cb719d571e903738520f8470911548ca2cc19"
-  integrity sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==
   dependencies:
     mime-db "~1.36.0"
 
 mime@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
-  integrity sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
-  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
 minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
 
 minimist@0.0.8:
   version "0.0.8"
   resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
 minimist@^1.2.0:
   version "1.2.0"
   resolved "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
 minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
 mixin-deep@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
-  integrity sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
@@ -2184,14 +1862,12 @@ mixin-deep@^1.2.0:
 mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
 
 mocha-jenkins-reporter@^0.3.9:
   version "0.3.12"
   resolved "https://registry.yarnpkg.com/mocha-jenkins-reporter/-/mocha-jenkins-reporter-0.3.12.tgz#fde358a542853598e243d68c585f10c21bcc9417"
-  integrity sha512-iSRJRA/3zJgyZ6MajwyRcjPBK5axu53huRVJ/W2OPI17YqbO62By88ucZmrNvWB1qY96GjUtkA4s6Fv4CGl0sA==
   dependencies:
     diff "1.0.7"
     mkdirp "0.5.1"
@@ -2201,7 +1877,6 @@ mocha-jenkins-reporter@^0.3.9:
 mocha@^3.0.0:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
-  integrity sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==
   dependencies:
     browser-stdout "1.3.0"
     commander "2.9.0"
@@ -2219,7 +1894,6 @@ mocha@^3.0.0:
 mocha@^4.0.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-4.1.0.tgz#7d86cfbcf35cb829e2754c32e17355ec05338794"
-  integrity sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==
   dependencies:
     browser-stdout "1.3.0"
     commander "2.11.0"
@@ -2235,22 +1909,18 @@ mocha@^4.0.1:
 moment@2.x.x, moment@^2.10.3:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
-  integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
 
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
 ms@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
-  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
 nanomatch@^1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.9.tgz#879f7150cb2dab7a471259066c104eee6e0fa7c2"
-  integrity sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==
   dependencies:
     arr-diff "^4.0.0"
     array-unique "^0.3.2"
@@ -2268,7 +1938,6 @@ nanomatch@^1.2.9:
 nock@^9.2.6, nock@^9.6.1:
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/nock/-/nock-9.6.1.tgz#d96e099be9bc1d0189a77f4490bbbb265c381b49"
-  integrity sha512-EDgl/WgNQ0C1BZZlASOQkQdE6tAWXJi8QQlugqzN64JJkvZ7ILijZuG24r4vCC7yOfnm6HKpne5AGExLGCeBWg==
   dependencies:
     chai "^4.1.2"
     debug "^3.1.0"
@@ -2283,12 +1952,10 @@ nock@^9.2.6, nock@^9.6.1:
 node-forge@^0.7.4:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
-  integrity sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==
 
 normalize-package-data@^2.3.2:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
-  integrity sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==
   dependencies:
     hosted-git-info "^2.1.4"
     is-builtin-module "^1.0.0"
@@ -2298,19 +1965,16 @@ normalize-package-data@^2.3.2:
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
-  integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
-  integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
 nyc@^11.4.1:
   version "11.9.0"
   resolved "https://registry.yarnpkg.com/nyc/-/nyc-11.9.0.tgz#4106e89e8fbe73623a1fc8b6ecb7abaa271ae1e4"
-  integrity sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==
   dependencies:
     archy "^1.0.0"
     arrify "^1.0.1"
@@ -2343,22 +2007,18 @@ nyc@^11.4.1:
 oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
-  integrity sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=
 
 oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
-  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
 object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-copy@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
-  integrity sha1-fn2Fi3gb18mRpBupde04EnVOmYw=
   dependencies:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
@@ -2367,28 +2027,24 @@ object-copy@^0.1.0:
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
-  integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
   dependencies:
     isobject "^3.0.0"
 
 object.pick@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
-  integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
   dependencies:
     isobject "^3.0.1"
 
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
 
 optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
-  integrity sha1-2j6nRob6IaGaERwybpDrFaAZZoY=
   dependencies:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
@@ -2396,12 +2052,10 @@ optimist@^0.6.1:
 os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
-  integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
 
 os-locale@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
-  integrity sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==
   dependencies:
     execa "^0.7.0"
     lcid "^1.0.0"
@@ -2410,75 +2064,62 @@ os-locale@^2.0.0:
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
-  integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
 p-limit@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c"
-  integrity sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==
   dependencies:
     p-try "^1.0.0"
 
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
-  integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
   dependencies:
     p-limit "^1.1.0"
 
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
-  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
-  integrity sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=
   dependencies:
     error-ex "^1.2.0"
 
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
-  integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
-  integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
-  integrity sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=
   dependencies:
     pinkie-promise "^2.0.0"
 
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
-  integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
 path-key@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
-  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
 path-parse@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
-  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
-  integrity sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=
   dependencies:
     graceful-fs "^4.1.2"
     pify "^2.0.0"
@@ -2487,46 +2128,38 @@ path-type@^1.0.0:
 pathval@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
-  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
 
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-  integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
-  integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
 
 pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
-  integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
-  integrity sha1-ITXW36ejWMBprJsXh3YogihFD/o=
   dependencies:
     pinkie "^2.0.0"
 
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
-  integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
 pkg-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
-  integrity sha1-ektQio1bstYp1EcFb/TpyTFM89Q=
   dependencies:
     find-up "^1.0.0"
 
 portfinder@^1.0.13:
   version "1.0.17"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.17.tgz#a8a1691143e46c4735edefcf4fbcccedad26456a"
-  integrity sha512-syFcRIRzVI1BoEFOCaAiizwDolh1S1YXSodsVhncbhjzjZQulhczNRbqnUl9N31Q4dKGOXsNDqxC2BWBgSMqeQ==
   dependencies:
     async "^1.5.2"
     debug "^2.2.0"
@@ -2535,59 +2168,48 @@ portfinder@^1.0.13:
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
-  integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
 progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
-  integrity sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=
 
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
   dependencies:
     asap "~2.0.3"
 
 propagate@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-1.0.0.tgz#00c2daeedda20e87e3782b344adba1cddd6ad709"
-  integrity sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=
 
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
-  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
 psl@^1.1.24:
   version "1.1.29"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
-  integrity sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==
 
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
-  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-  integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
 qs@^6.5.1, qs@~6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
-  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
-  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
-  integrity sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=
   dependencies:
     find-up "^1.0.0"
     read-pkg "^1.0.0"
@@ -2595,7 +2217,6 @@ read-pkg-up@^1.0.1:
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
-  integrity sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=
   dependencies:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
@@ -2604,19 +2225,16 @@ read-pkg@^1.0.0:
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
   dependencies:
     resolve "^1.1.6"
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
-  integrity sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
@@ -2624,31 +2242,26 @@ regex-not@^1.0.0, regex-not@^1.0.2:
 repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
-  integrity sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=
 
 repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
-  integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
 repeating@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
-  integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
 
 request-promise-core@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
-  integrity sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=
   dependencies:
     lodash "^4.13.1"
 
 request-promise@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.2.tgz#d1ea46d654a6ee4f8ee6a4fea1018c22911904b4"
-  integrity sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=
   dependencies:
     bluebird "^3.5.0"
     request-promise-core "1.1.1"
@@ -2658,7 +2271,6 @@ request-promise@^4.2.2:
 request@^2.69.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
-  integrity sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.6.0"
@@ -2684,7 +2296,6 @@ request@^2.69.0:
 request@^2.83.0, request@^2.85.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
-  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -2710,112 +2321,92 @@ request@^2.83.0, request@^2.85.0:
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
-  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
-  integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
 
 resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
-  integrity sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=
 
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
-  integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
 resolve@^1.1.6:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
-  integrity sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==
   dependencies:
     path-parse "^1.0.5"
 
 resolve@^1.3.2:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
-  integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
   dependencies:
     path-parse "^1.0.5"
 
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
-  integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
 retry-axios@0.3.2, retry-axios@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/retry-axios/-/retry-axios-0.3.2.tgz#5757c80f585b4cc4c4986aa2ffd47a60c6d35e13"
-  integrity sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ==
 
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
-  integrity sha1-YTObci/mo1FWiSENJOFMlhSGE+8=
   dependencies:
     align-text "^0.1.1"
 
 rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
-  integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
   dependencies:
     glob "^7.0.5"
 
 rsa-pem-from-mod-exp@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz#362a42c6d304056d493b3f12bceabb2c6576a6d4"
-  integrity sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ=
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
-  integrity sha1-QKNmnzsHfR6UPURinhV91IAjvy4=
   dependencies:
     ret "~0.1.10"
 
 safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
-  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 sax@1.2.1:
   version "1.2.1"
   resolved "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
-  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
 
 sax@>=0.6.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 "semver@2 || 3 || 4 || 5", semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
-  integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
 
 semver@^5.3.0:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
-  integrity sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==
 
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
-  integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
 set-value@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
-  integrity sha1-fbCPnT0i3H945Trzw79GZuzfzPE=
   dependencies:
     extend-shallow "^2.0.1"
     is-extendable "^0.1.1"
@@ -2825,7 +2416,6 @@ set-value@^0.4.3:
 set-value@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
-  integrity sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==
   dependencies:
     extend-shallow "^2.0.1"
     is-extendable "^0.1.1"
@@ -2835,19 +2425,16 @@ set-value@^2.0.0:
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
-  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
   dependencies:
     shebang-regex "^1.0.0"
 
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
-  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
 shelljs@^0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.2.tgz#345b7df7763f4c2340d584abb532c5f752ca9e35"
-  integrity sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
@@ -2856,22 +2443,18 @@ shelljs@^0.8.1:
 signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
-  integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
 simple-mock@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/simple-mock/-/simple-mock-0.8.0.tgz#49c9a223fa6eea8e2c4fd6948fe8300cd8a594f3"
-  integrity sha1-ScmiI/pu6o4sT9aUj+gwDNillPM=
 
 slide@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
-  integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
-  integrity sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==
   dependencies:
     define-property "^1.0.0"
     isobject "^3.0.0"
@@ -2880,14 +2463,12 @@ snapdragon-node@^2.0.1:
 snapdragon-util@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
-  integrity sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==
   dependencies:
     kind-of "^3.2.0"
 
 snapdragon@^0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d"
-  integrity sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==
   dependencies:
     base "^0.11.1"
     debug "^2.2.0"
@@ -2901,7 +2482,6 @@ snapdragon@^0.8.1:
 source-map-resolve@^0.5.0:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
-  integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==
   dependencies:
     atob "^2.1.1"
     decode-uri-component "^0.2.0"
@@ -2912,14 +2492,12 @@ source-map-resolve@^0.5.0:
 source-map-support@^0.5.0:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.4.tgz#54456efa89caa9270af7cd624cc2f123e51fbae8"
-  integrity sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==
   dependencies:
     source-map "^0.6.0"
 
 source-map-support@^0.5.9:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
-  integrity sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -2927,29 +2505,24 @@ source-map-support@^0.5.9:
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
-  integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
-  integrity sha1-66T12pwNyZneaAMti092FzZSA2s=
   dependencies:
     amdefine ">=0.0.4"
 
 source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-  integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
 source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 spawn-wrap@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.4.2.tgz#cff58e73a8224617b6561abdc32586ea0c82248c"
-  integrity sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==
   dependencies:
     foreground-child "^1.5.6"
     mkdirp "^0.5.0"
@@ -2961,7 +2534,6 @@ spawn-wrap@^1.4.2:
 spdx-correct@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
-  integrity sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==
   dependencies:
     spdx-expression-parse "^3.0.0"
     spdx-license-ids "^3.0.0"
@@ -2969,12 +2541,10 @@ spdx-correct@^3.0.0:
 spdx-exceptions@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
-  integrity sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==
 
 spdx-expression-parse@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
-  integrity sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==
   dependencies:
     spdx-exceptions "^2.1.0"
     spdx-license-ids "^3.0.0"
@@ -2982,29 +2552,24 @@ spdx-expression-parse@^3.0.0:
 spdx-license-ids@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
-  integrity sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
-  integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
 
 sprintf-js@^1.0.3:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
-  integrity sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=
 
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
-  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 sshpk@^1.7.0:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.2.tgz#c6fc61648a3d9c4e764fd3fcdf4ea105e492ba98"
-  integrity sha1-xvxhZIo9nE52T9P8306hBeSSupg=
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
@@ -3020,7 +2585,6 @@ sshpk@^1.7.0:
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
-  integrity sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=
   dependencies:
     define-property "^0.2.5"
     object-copy "^0.1.0"
@@ -3028,17 +2592,14 @@ static-extend@^0.1.1:
 stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
-  integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
 string-template@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-1.0.0.tgz#9e9f2233dc00f218718ec379a28a5673ecca8b96"
-  integrity sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y=
 
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
-  integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
   dependencies:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
@@ -3047,7 +2608,6 @@ string-width@^1.0.1:
 string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
-  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
@@ -3055,81 +2615,68 @@ string-width@^2.0.0, string-width@^2.1.1:
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
 
 strip-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
-  integrity sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=
   dependencies:
     is-utf8 "^0.2.0"
 
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
-  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
-  integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
 strip-json-comments@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
 striptags@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/striptags/-/striptags-3.1.1.tgz#c8c3e7fdd6fb4bb3a32a3b752e5b5e3e38093ebd"
-  integrity sha1-yMPn/db7S7OjKjt1LltePjgJPr0=
 
 supports-color@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
-  integrity sha1-cqJiiU2dQIuVbKBf83su2KbiotU=
   dependencies:
     has-flag "^1.0.0"
 
 supports-color@4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
-  integrity sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==
   dependencies:
     has-flag "^2.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
 supports-color@^3.1.2:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
-  integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
   dependencies:
     has-flag "^1.0.0"
 
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
-  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
 
 test-exclude@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
-  integrity sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==
   dependencies:
     arrify "^1.0.1"
     micromatch "^3.1.8"
@@ -3140,19 +2687,16 @@ test-exclude@^4.2.0:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
-  integrity sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=
 
 to-object-path@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
-  integrity sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=
   dependencies:
     kind-of "^3.0.2"
 
 to-regex-range@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
-  integrity sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=
   dependencies:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
@@ -3160,7 +2704,6 @@ to-regex-range@^2.1.0:
 to-regex@^3.0.1, to-regex@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
-  integrity sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==
   dependencies:
     define-property "^2.0.2"
     extend-shallow "^3.0.2"
@@ -3170,21 +2713,18 @@ to-regex@^3.0.1, to-regex@^3.0.2:
 topo@1.x.x:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/topo/-/topo-1.1.0.tgz#e9d751615d1bb87dc865db182fa1ca0a5ef536d5"
-  integrity sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=
   dependencies:
     hoek "2.x.x"
 
 tough-cookie@>=2.3.3, tough-cookie@~2.3.3:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
-  integrity sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==
   dependencies:
     punycode "^1.4.1"
 
 tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
-  integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
@@ -3192,12 +2732,10 @@ tough-cookie@~2.4.3:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
-  integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
 ts-node@^4.0.2:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-4.1.0.tgz#36d9529c7b90bb993306c408cd07f7743de20712"
-  integrity sha512-xcZH12oVg9PShKhy3UHyDmuDLV3y7iKwX25aMVPt1SIXSuAfWkFiGPEkg+th8R4YKW/QCxDoW7lJdb15lx6QWg==
   dependencies:
     arrify "^1.0.0"
     chalk "^2.3.0"
@@ -3213,7 +2751,6 @@ ts-node@^4.0.2:
 tsconfig@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-7.0.0.tgz#84538875a4dc216e5c4a5432b3a4dec3d54e91b7"
-  integrity sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==
   dependencies:
     "@types/strip-bom" "^3.0.0"
     "@types/strip-json-comments" "0.0.30"
@@ -3223,19 +2760,16 @@ tsconfig@^7.0.0:
 tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
-  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
 tslint-no-unused-expression-chai@^0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tslint-no-unused-expression-chai/-/tslint-no-unused-expression-chai-0.0.3.tgz#455d57db2badf12a1434b2de578f1ffae63eca76"
-  integrity sha512-jKqhimj5gKl96ngeKxSVG1nOE7wmKRiHXD3kKpi+GG+5CmXJevD0ogsThZ8uSQCBIELFLVqXpZ43PpLniWu7jw==
   dependencies:
     tsutils "^2.3.0"
 
 tslint@^5.8.0:
   version "5.11.0"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
-  integrity sha1-mPMMAurjzecAYgHkwzywi0hYHu0=
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"
@@ -3253,43 +2787,36 @@ tslint@^5.8.0:
 tsutils@^2.27.2:
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
-  integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
   dependencies:
     tslib "^1.8.1"
 
 tsutils@^2.3.0:
   version "2.26.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.26.1.tgz#9e4a0cb9ff173863f34c22a961969081270d1878"
-  integrity sha512-bnm9bcjOqOr1UljleL94wVCDlpa6KjfGaTkefeLch4GRafgDkROxPizbB/FxTEdI++5JqhxczRy/Qub0syNqZA==
   dependencies:
     tslib "^1.8.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
-  integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
-  integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
 type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
-  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 typedoc-default-themes@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
-  integrity sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=
 
 typedoc@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.11.1.tgz#9f033887fd2218c769e1045feb88a1efed9f12c9"
-  integrity sha512-jdNIoHm5wkZqxQTe/g9AQ3LKnZyrzHXqu6A/c9GUOeJyBWLxNr7/Dm3rwFvLksuxRNwTvY/0HRDU9sJTa9WQSg==
   dependencies:
     "@types/fs-extra" "5.0.1"
     "@types/handlebars" "4.0.36"
@@ -3312,17 +2839,14 @@ typedoc@^0.11.1:
 typescript@2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
 
 typescript@^2.6.2:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
-  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
 uglify-js@^2.6:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
-  integrity sha1-KcVzMUgFe7Th913zW3qcty5qWd0=
   dependencies:
     source-map "~0.5.1"
     yargs "~3.10.0"
@@ -3332,12 +2856,10 @@ uglify-js@^2.6:
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
-  integrity sha1-bgkk1r2mta/jSeOabWMoUKD4grc=
 
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
-  integrity sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=
   dependencies:
     arr-union "^3.1.0"
     get-value "^2.0.6"
@@ -3347,12 +2869,10 @@ union-value@^1.0.0:
 universalify@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
-  integrity sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=
 
 unset-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
-  integrity sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
@@ -3360,22 +2880,18 @@ unset-value@^1.0.0:
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
-  integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
 url-join@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-1.1.0.tgz#741c6c2f4596c4830d6718460920d0c92202dc78"
-  integrity sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=
 
 url-join@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-3.0.0.tgz#26e8113ace195ea30d0fc38186e45400f9cea672"
-  integrity sha1-JugROs4ZXqMND8OBhuRUAPnOpnI=
 
 url@0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
-  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
@@ -3383,31 +2899,26 @@ url@0.10.3:
 use@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.0.tgz#14716bf03fdfefd03040aef58d8b4b85f3a7c544"
-  integrity sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==
   dependencies:
     kind-of "^6.0.2"
 
 uuid@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
-  integrity sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==
 
 uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
-  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 v8flags@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.0.2.tgz#ad6a78a20a6b23d03a8debc11211e3cc23149477"
-  integrity sha512-6sgSKoFw1UpUPd3cFdF7QGnrH6tDeBgW1F3v9gy8gLY0mlbiBXq8soy8aQpY6xeeCjH5K+JvC62Acp7gtl7wWA==
   dependencies:
     homedir-polyfill "^1.0.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
-  integrity sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
@@ -3415,7 +2926,6 @@ validate-npm-package-license@^3.0.1:
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
-  integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
   dependencies:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
@@ -3424,7 +2934,6 @@ verror@1.10.0:
 virtual-alexa@^0.6.6:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/virtual-alexa/-/virtual-alexa-0.6.6.tgz#240c36f7074fde22cf1dde674fff8f82b0f815f4"
-  integrity sha512-sxJ+O+0/8rtV6hunSQpHj4at7PPEV13QqYP0ViYeXivm64xrL4HKcq9irjXtWKbUlnFWv3tFtZEN4Pk6+ccTUg==
   dependencies:
     aws-sdk "^2.246.1"
     lodash "^4.17.10"
@@ -3435,7 +2944,6 @@ virtual-alexa@^0.6.6:
 virtual-core@0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/virtual-core/-/virtual-core-0.0.11.tgz#1503edaa234f082a2da5cefcde376758ac0d137e"
-  integrity sha1-FQPtqiNPCCotpc783jdnWKwNE34=
   dependencies:
     "@types/uuid" "^3.4.3"
     uuid "^3.2.1"
@@ -3443,7 +2951,6 @@ virtual-core@0.0.11:
 virtual-core@0.0.12:
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/virtual-core/-/virtual-core-0.0.12.tgz#631ade1c7f168992b8e23532581e90167faa19d4"
-  integrity sha1-YxreHH8WiZK44jUyWB6QFn+qGdQ=
   dependencies:
     "@types/uuid" "^3.4.3"
     uuid "^3.2.1"
@@ -3451,7 +2958,6 @@ virtual-core@0.0.12:
 virtual-google-assistant@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/virtual-google-assistant/-/virtual-google-assistant-0.2.5.tgz#265d35a4917e9095256440856bd70c7e4130e944"
-  integrity sha512-w5161tXrwFUNlYzTxOEuS/BsP3G+c1NeZ3tAuRPyppGG6XN+AJNICjH+ztpar33olH2hUoijWb9bsaE5vHWvsA==
   dependencies:
     "@types/uuid" "^3.4.1"
     lodash "^4.17.4"
@@ -3461,34 +2967,28 @@ virtual-google-assistant@^0.2.5:
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
-  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
 which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
-  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
 
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
-  integrity sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=
 
 wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
-  integrity sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=
 
 wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
-  integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
 
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
-  integrity sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
@@ -3496,12 +2996,10 @@ wrap-ansi@^2.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 write-file-atomic@^1.1.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.4.tgz#f807a4f0b1d9e913ae7a48112e6cc3af1991b45f"
-  integrity sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=
   dependencies:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
@@ -3510,7 +3008,6 @@ write-file-atomic@^1.1.4:
 xml2js@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
-  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
@@ -3518,46 +3015,38 @@ xml2js@0.4.19:
 xml@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
-  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
-  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xtend@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
-  integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
 
 y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-  integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
 
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
-  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yargs-parser@^8.0.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
-  integrity sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==
   dependencies:
     camelcase "^4.1.0"
 
 yargs-parser@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
-  integrity sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=
   dependencies:
     camelcase "^4.1.0"
 
 yargs@11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
-  integrity sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==
   dependencies:
     cliui "^4.0.0"
     decamelize "^1.1.1"
@@ -3575,7 +3064,6 @@ yargs@11.1.0:
 yargs@~3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
-  integrity sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=
   dependencies:
     camelcase "^1.0.2"
     cliui "^2.1.0"
@@ -3585,4 +3073,3 @@ yargs@~3.10.0:
 yn@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
-  integrity sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=


### PR DESCRIPTION
Please review the code first, this code has room for improvement.

The `ask-sdk-model` package has the new types for APL related requests and intents but updating the package lead to several changes for type definitions.

The `set` and `get` methods from `lodash` were mainly used to get a property that is not in all request definitions anymore.

The CanFullfillIntent definition was removed from the `ask-sdk-model` package so the definitions from the beta version we used were added.