### PR TITLE
Fixes onUnhandledState not being called

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voxa",
-  "version": "3.0.0-alpha36",
+  "version": "3.0.0-alpha37",
   "description": "A fsm (state machine) framework for Alexa apps using Node.js",
   "main": "./lib/src/index.js",
   "types": "./lib/src/index.d.ts",

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -26,12 +26,13 @@ export { TimeoutError } from "./TimeoutError";
 export { errorHandler } from "./handler";
 
 function createError(messageTemplate: string, key: string) {
-  return class extends Error {
+  return class implements Error {
+    public name: string = key;
+    public message: string;
     [key: string]: any;
 
     constructor(value: string) {
-      const message = messageTemplate.replace("{" + key + "}", value);
-      super(message);
+      this.message = messageTemplate.replace("{" + key + "}", value);
       this[key] = value;
     }
   };


### PR DESCRIPTION
Error classes now are implemented instead of extended. This line
https://github.com/VoxaAI/voxa/blob/v3/src/StateMachine/StateMachine.ts#L145

was not working when the `UnknownState` Error was thrown