### PR TITLE
Integrate APL directives

### DIFF
--- a/docs/alexa-directives.rst
+++ b/docs/alexa-directives.rst
@@ -74,7 +74,7 @@ RenderTemplate
 
 `Alexa Documentation <https://developer.amazon.com/docs/custom-skills/display-interface-reference.html>`_
 
-Voxa provides a `DisplayTemplate` builder that can be used with the `alexaRenderTemplate` controller key to create Displa templates for the echo show and echo spot.
+Voxa provides a `DisplayTemplate` builder that can be used with the `alexaRenderTemplate` controller key to create Display templates for the echo show and echo spot.
 
 .. code-block:: javascript
 

--- a/docs/alexa-directives.rst
+++ b/docs/alexa-directives.rst
@@ -95,6 +95,121 @@ Voxa provides a `DisplayTemplate` builder that can be used with the `alexaRender
     });
 
 
+Alexa Presentation Language (APL) Templates
+--------------
+
+`Alexa Documentation <https://developer.amazon.com/docs/alexa-presentation-language/apl-overview.html>`_
+
+An APL Template is sent with the `alexaAPLTemplate` key in your controller. You can pass the directive object directly or a view name with the directive object.
+
+One important thing to know is that is you sent a Render Template and a APL Template in the same response but the APL Template will be the one being rendered if the device supports it; if not, the Render Template will be one being rendered.
+
+.. code-block:: javascript
+
+  // variables.js
+
+    exports.MyAPLTemplate = (voxaEvent) => {
+      // Do something with the voxaEvent, or not...
+
+      return {
+        datasources: {},
+        document: {},
+        token: "SkillTemplateToken",
+        type: "Alexa.Presentation.APL.RenderDocument",
+      };
+    });
+
+  // views.js
+
+    const views = {
+      "en-US": {
+        translation: {
+          MyAPLTemplate: "{MyAPLTemplate}"
+        },
+      };
+    };
+
+  // state.js
+
+    app.onState('someState', () => {
+      return {
+        alexaAPLTemplate: "MyAPLTemplate",
+      };
+    });
+
+    // Or you can do it directly...
+
+    app.onState('someState', () => {
+      return {
+        alexaAPLTemplate: {
+          datasources: {},
+          document: {},
+          token: "SkillTemplateToken",
+          type: "Alexa.Presentation.APL.RenderDocument",
+        },
+      };
+    });
+
+
+Alexa Presentation Language (APL) Commands
+--------------
+
+`Alexa Documentation <https://developer.amazon.com/docs/alexa-presentation-language/apl-commands.html>`_
+
+An APL Command is sent with the `alexaAPLCommand` key in your controller. Just like the APL Template, you can pass the directive object directly or a view name with the directive object.
+
+.. code-block:: javascript
+
+  // variables.js
+
+    exports.MyAPLCommand = (voxaEvent) => {
+      // Do something with the voxaEvent, or not...
+
+      return {
+        token: "SkillTemplateToken",
+        type: "Alexa.Presentation.APL.ExecuteCommands";
+        commands: [{
+          type: "SpeakItem", // Karaoke type command
+          componentId: "someAPLComponent";
+        }],
+      };
+    });
+
+  // views.js
+
+    const views = {
+      "en-US": {
+        translation: {
+          MyAPLCommand: "{MyAPLCommand}"
+        },
+      };
+    };
+
+  // state.js
+
+    app.onState('someState', () => {
+      return {
+        alexaAPLCommand: "MyAPLCommand",
+      };
+    });
+
+    // Or you can do it directly...
+
+    app.onState('someState', () => {
+      return {
+        alexaAPLCommand: {
+          token: "SkillTemplateToken",
+          type: "Alexa.Presentation.APL.ExecuteCommands";
+          commands: [{
+            type: "SpeakItem", // Karaoke type command
+            componentId: "someAPLComponent";
+          }],
+        },
+      };
+    });
+
+
+
 PlayAudio
 ---------
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export {
   AlexaPlatform,
   AccountLinkingCard as AlexaAccountLinkingCard,
   AlexaEvent,
+  APLCommand,
   APLTemplate,
   ANCHOR_ENUM,
   ConnectionsSendRequest,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export {
   AlexaPlatform,
   AccountLinkingCard as AlexaAccountLinkingCard,
   AlexaEvent,
+  APLTemplate,
   ANCHOR_ENUM,
   ConnectionsSendRequest,
   DialogDelegate,

--- a/src/platforms/alexa/AlexaEvent.ts
+++ b/src/platforms/alexa/AlexaEvent.ts
@@ -53,6 +53,7 @@ export class AlexaEvent extends VoxaEvent {
   };
 
   public requestToIntent: any = {
+    "Alexa.Presentation.APL.UserEvent": "Alexa.Presentation.APL.UserEvent",
     "Connections.Response": "Connections.Response",
     "Display.ElementSelected": "Display.ElementSelected",
     "GameEngine.InputHandlerEvent": "GameEngine.InputHandlerEvent",

--- a/src/platforms/alexa/AlexaPlatform.ts
+++ b/src/platforms/alexa/AlexaPlatform.ts
@@ -106,8 +106,6 @@ export class AlexaPlatform extends VoxaPlatform {
   public getDirectiveHandlers() {
     return [
       AccountLinkingCard,
-      APLTemplate,
-      APLCommand,
       ConnectionsSendRequest,
       DialogDelegate,
       GadgetControllerLightDirective,
@@ -117,6 +115,8 @@ export class AlexaPlatform extends VoxaPlatform {
       HomeCard,
       PlayAudio,
       RenderTemplate,
+      APLTemplate,
+      APLCommand,
       StopAudio,
     ];
   }

--- a/src/platforms/alexa/AlexaPlatform.ts
+++ b/src/platforms/alexa/AlexaPlatform.ts
@@ -33,6 +33,7 @@ import { AlexaEvent } from "./AlexaEvent";
 import { AlexaReply } from "./AlexaReply";
 import {
   AccountLinkingCard,
+  APLTemplate,
   ConnectionsSendRequest,
   DialogDelegate,
   GadgetControllerLightDirective,
@@ -104,6 +105,7 @@ export class AlexaPlatform extends VoxaPlatform {
   public getDirectiveHandlers() {
     return [
       AccountLinkingCard,
+      APLTemplate,
       ConnectionsSendRequest,
       DialogDelegate,
       GadgetControllerLightDirective,

--- a/src/platforms/alexa/AlexaPlatform.ts
+++ b/src/platforms/alexa/AlexaPlatform.ts
@@ -68,6 +68,7 @@ const AlexaRequests = [
   "Display.ElementSelected",
   "CanFulfillIntentRequest",
   "GameEngine.InputHandlerEvent",
+  "Alexa.Presentation.APL.UserEvent",
 ];
 
 export interface IAlexaPlatformConfig extends IVoxaPlatformConfig {

--- a/src/platforms/alexa/AlexaPlatform.ts
+++ b/src/platforms/alexa/AlexaPlatform.ts
@@ -33,6 +33,7 @@ import { AlexaEvent } from "./AlexaEvent";
 import { AlexaReply } from "./AlexaReply";
 import {
   AccountLinkingCard,
+  APLCommand,
   APLTemplate,
   ConnectionsSendRequest,
   DialogDelegate,
@@ -106,6 +107,7 @@ export class AlexaPlatform extends VoxaPlatform {
     return [
       AccountLinkingCard,
       APLTemplate,
+      APLCommand,
       ConnectionsSendRequest,
       DialogDelegate,
       GadgetControllerLightDirective,

--- a/src/platforms/alexa/directives.ts
+++ b/src/platforms/alexa/directives.ts
@@ -229,6 +229,50 @@ export class RenderTemplate extends AlexaDirective implements IDirective {
   }
 }
 
+export class APLTemplate extends AlexaDirective implements IDirective {
+  public static key: string = "alexaAPLTemplate";
+  public static platform: string = "alexa";
+
+  public viewPath?: string;
+  public directive?: interfaces.alexa.presentation.apl.RenderDocumentDirective;
+
+  constructor(viewPath: string | interfaces.alexa.presentation.apl.RenderDocumentDirective) {
+    super();
+
+    if (_.isString(viewPath)) {
+      this.viewPath = viewPath;
+    } else {
+      this.directive = viewPath;
+    }
+  }
+
+  public async writeToReply(
+    reply: IVoxaReply,
+    event: IVoxaEvent,
+    transition: ITransition,
+  ): Promise<void> {
+    this.validateReply(reply);
+
+    if (!_.includes(event.supportedInterfaces, "Alexa.Presentation.APL")) {
+      return;
+    }
+
+    if (this.viewPath) {
+      this.directive = await event.renderer.renderPath(this.viewPath, event);
+    }
+
+    this.addDirective(reply);
+  }
+
+  private validateReply(reply: IVoxaReply) {
+    if (reply.hasDirective("Alexa.Presentation.APL.RenderDocument")) {
+      throw new Error(
+        "At most one Alexa.Presentation.APL.RenderDocument directive can be specified in a response",
+      );
+    }
+  }
+}
+
 export class AccountLinkingCard implements IDirective {
   public static key: string = "alexaAccountLinkingCard";
   public static platform: string = "alexa";

--- a/src/platforms/alexa/directives.ts
+++ b/src/platforms/alexa/directives.ts
@@ -273,6 +273,50 @@ export class APLTemplate extends AlexaDirective implements IDirective {
   }
 }
 
+export class APLCommand extends AlexaDirective implements IDirective {
+  public static key: string = "alexaAPLCommand";
+  public static platform: string = "alexa";
+
+  public viewPath?: string;
+  public directive?: interfaces.alexa.presentation.apl.ExecuteCommandsDirective;
+
+  constructor(viewPath: string | interfaces.alexa.presentation.apl.ExecuteCommandsDirective) {
+    super();
+
+    if (_.isString(viewPath)) {
+      this.viewPath = viewPath;
+    } else {
+      this.directive = viewPath;
+    }
+  }
+
+  public async writeToReply(
+    reply: IVoxaReply,
+    event: IVoxaEvent,
+    transition: ITransition,
+  ): Promise<void> {
+    this.validateReply(reply);
+
+    if (!_.includes(event.supportedInterfaces, "Alexa.Presentation.APL")) {
+      return;
+    }
+
+    if (this.viewPath) {
+      this.directive = await event.renderer.renderPath(this.viewPath, event);
+    }
+
+    this.addDirective(reply);
+  }
+
+  private validateReply(reply: IVoxaReply) {
+    if (reply.hasDirective("Alexa.Presentation.APL.ExecuteCommands")) {
+      throw new Error(
+        "At most one Alexa.Presentation.APL.ExecuteCommands directive can be specified in a response",
+      );
+    }
+  }
+}
+
 export class AccountLinkingCard implements IDirective {
   public static key: string = "alexaAccountLinkingCard";
   public static platform: string = "alexa";

--- a/src/platforms/alexa/index.ts
+++ b/src/platforms/alexa/index.ts
@@ -5,6 +5,7 @@ export { DisplayTemplate } from "./DisplayTemplateBuilder";
 export { ANCHOR_ENUM, EVENT_REPORT_ENUM, GameEngine } from "./GameEngine";
 export {
   AccountLinkingCard,
+  APLCommand,
   APLTemplate,
   ConnectionsSendRequest,
   DialogDelegate,

--- a/src/platforms/alexa/index.ts
+++ b/src/platforms/alexa/index.ts
@@ -5,6 +5,7 @@ export { DisplayTemplate } from "./DisplayTemplateBuilder";
 export { ANCHOR_ENUM, EVENT_REPORT_ENUM, GameEngine } from "./GameEngine";
 export {
   AccountLinkingCard,
+  APLTemplate,
   ConnectionsSendRequest,
   DialogDelegate,
   GadgetControllerLightDirective,

--- a/test/VoxaApp.spec.ts
+++ b/test/VoxaApp.spec.ts
@@ -65,6 +65,18 @@ describe("VoxaApp", () => {
     };
   });
 
+  it("should have the APL Template directive before the APL Command directive in the Alexa Platform", () => {
+    // The APL Template should always be before the APL Command in the directives array in order to work.
+    // Don't ask why, that's how Amazon likes it.
+    const voxaApp = new VoxaApp({ variables, views });
+    const platform = new AlexaPlatform(voxaApp);
+
+    const APLTemplateIndex = voxaApp.directiveHandlers.findIndex(((directive) => directive.key === "alexaAPLTemplate"));
+    const APLCommandIndex = voxaApp.directiveHandlers.findIndex(((directive) => directive.key === "alexaAPLCommand"));
+
+    expect(APLTemplateIndex).to.be.lessThan(APLCommandIndex);
+  });
+
   it("should include the state in the session attributes", async () => {
     const voxaApp = new VoxaApp({ variables, views });
     const platform = new AlexaPlatform(voxaApp);

--- a/test/alexa/AlexaEvent.spec.ts
+++ b/test/alexa/AlexaEvent.spec.ts
@@ -60,6 +60,7 @@ describe("AlexaEvent", () => {
     const rawEvent = rb.getLaunchRequest();
     const alexaEvent = new AlexaEvent(rawEvent);
     expect(alexaEvent.supportedInterfaces).to.deep.equal([
+      "Alexa.Presentation.APL",
       "AudioPlayer",
       "Display",
     ]);

--- a/test/alexa/AlexaEvent.spec.ts
+++ b/test/alexa/AlexaEvent.spec.ts
@@ -73,6 +73,12 @@ describe("AlexaEvent", () => {
     const alexaEvent = new AlexaEvent(rawEvent) as IVoxaIntentEvent;
     expect(alexaEvent.intent.params).to.be.ok;
   });
+
+  it("should add AlexaPresentationAPLUserEvent intent params", () => {
+    const rawEvent = rb.getAlexaPresentationAPLUserEvent();
+    const alexaEvent = new AlexaEvent(rawEvent) as IVoxaIntentEvent;
+    expect(alexaEvent.intent.params).to.be.ok;
+  });
 });
 
 describe("LoginWithAmazon", () => {

--- a/test/alexa/directives.spec.ts
+++ b/test/alexa/directives.spec.ts
@@ -137,6 +137,43 @@ describe("Alexa directives", () => {
     });
   });
 
+  describe("APLCommand", () => {
+    it("should only add the command if request supports it", async () => {
+      app.onIntent("YesIntent", {
+        alexaAPLCommand: "APLKaraokeCommand",
+        to: "die",
+      });
+
+      event.context.System.device.supportedInterfaces = {};
+      const reply = await alexaSkill.execute(event);
+      expect(reply.response.directives).to.be.undefined;
+    });
+
+    it("should add to the directives", async () => {
+      app.onIntent("YesIntent", {
+        alexaAPLCommand: "APLKaraokeCommand",
+        to: "die",
+      });
+
+      const reply = await alexaSkill.execute(event);
+      expect(reply.response.directives).to.not.be.undefined;
+      expect(reply.response.directives).to.deep.equal([
+        {
+          commands: [
+            {
+              align: "center",
+              componentId: "textComponent",
+              highlightMode: "line",
+              type: "SpeakItem",
+            },
+          ],
+          token: "SkillTemplateToken",
+          type: "Alexa.Presentation.APL.ExecuteCommands",
+        },
+      ]);
+    });
+  });
+
   describe("Hint", () => {
     it("should render a Hint directive", async () => {
       app.onIntent("YesIntent", {

--- a/test/alexa/directives.spec.ts
+++ b/test/alexa/directives.spec.ts
@@ -135,6 +135,49 @@ describe("Alexa directives", () => {
         },
       ]);
     });
+
+    it("should be in the directives array after the RenderTemplate", async () => {
+      app.onIntent("YesIntent", {
+        alexaAPLTemplate: "APLTemplate",
+        alexaRenderTemplate: "RenderTemplate",
+        to: "die",
+      });
+
+      const reply = await alexaSkill.execute(event);
+      expect(reply.response.directives).to.not.be.undefined;
+      expect(reply.response.directives).to.deep.equal([
+        {
+          template: {
+            backButton: "VISIBLE",
+            backgroundImage: "Image",
+            textContent: {
+              primaryText: {
+                text: "string",
+                type: "string",
+              },
+              secondaryText: {
+                text: "string",
+                type: "string",
+              },
+              tertiaryText: {
+                text: "string",
+                type: "string",
+              },
+            },
+            title: "string",
+            token: "string",
+            type: "BodyTemplate1",
+          },
+          type: "Display.RenderTemplate",
+        },
+        {
+          datasources: {},
+          document: {},
+          token: "SkillTemplateToken",
+          type: "Alexa.Presentation.APL.RenderDocument",
+        },
+      ]);
+    });
   });
 
   describe("APLCommand", () => {

--- a/test/alexa/directives.spec.ts
+++ b/test/alexa/directives.spec.ts
@@ -104,6 +104,44 @@ describe("Alexa directives", () => {
         },
       ]);
     });
+
+    it("should be the only directive if APL is not supported", async () => {
+      app.onIntent("YesIntent", {
+        alexaAPLTemplate: "APLTemplate",
+        alexaRenderTemplate: "RenderTemplate",
+        to: "die",
+      });
+
+      event.context.System.device.supportedInterfaces = { Display: {} };
+      const reply = await alexaSkill.execute(event);
+      expect(reply.response.directives).to.not.be.undefined;
+      expect(reply.response.directives).to.deep.equal([
+        {
+          template: {
+            backButton: "VISIBLE",
+            backgroundImage: "Image",
+            textContent: {
+              primaryText: {
+                text: "string",
+                type: "string",
+              },
+              secondaryText: {
+                text: "string",
+                type: "string",
+              },
+              tertiaryText: {
+                text: "string",
+                type: "string",
+              },
+            },
+            title: "string",
+            token: "string",
+            type: "BodyTemplate1",
+          },
+          type: "Display.RenderTemplate",
+        },
+      ]);
+    });
   });
 
   describe("APLRenderTemplate", () => {

--- a/test/alexa/directives.spec.ts
+++ b/test/alexa/directives.spec.ts
@@ -6,6 +6,7 @@ import "mocha";
 import {
   AlexaEvent,
   AlexaPlatform,
+  APLTemplate,
   DisplayTemplate,
   HomeCard,
   VoxaApp,
@@ -100,6 +101,37 @@ describe("Alexa directives", () => {
             type: "BodyTemplate1",
           },
           type: "Display.RenderTemplate",
+        },
+      ]);
+    });
+  });
+
+  describe("APLRenderTemplate", () => {
+    it("should only add the template if request supports it", async () => {
+      app.onIntent("YesIntent", {
+        alexaAPLTemplate: "APLTemplate",
+        to: "die",
+      });
+
+      event.context.System.device.supportedInterfaces = {};
+      const reply = await alexaSkill.execute(event);
+      expect(reply.response.directives).to.be.undefined;
+    });
+
+    it("should add to the directives", async () => {
+      app.onIntent("YesIntent", {
+        alexaAPLTemplate: "APLTemplate",
+        to: "die",
+      });
+
+      const reply = await alexaSkill.execute(event);
+      expect(reply.response.directives).to.not.be.undefined;
+      expect(reply.response.directives).to.deep.equal([
+        {
+          datasources: {},
+          document: {},
+          token: "SkillTemplateToken",
+          type: "Alexa.Presentation.APL.RenderDocument",
         },
       ]);
     });

--- a/test/tools.ts
+++ b/test/tools.ts
@@ -127,8 +127,9 @@ export class AlexaRequestBuilder {
         device: {
           deviceId: this.deviceId,
           supportedInterfaces: {
-            AudioPlayer: {},
-            Display: {},
+            "Alexa.Presentation.APL": {},
+            "AudioPlayer": {},
+            "Display": {},
           },
         },
         user: {

--- a/test/tools.ts
+++ b/test/tools.ts
@@ -61,6 +61,20 @@ export class AlexaRequestBuilder {
     };
   }
 
+  public getAlexaPresentationAPLUserEvent(): RequestEnvelope {
+    return {
+      context: this.getContextData(),
+      request: {
+        arguments: [],
+        requestId: `EdwRequestId.${v1()}`,
+        timestamp: new Date().toISOString(),
+        type: "Alexa.Presentation.APL.UserEvent",
+      },
+      session: this.getSessionData(),
+      version: this.version,
+    };
+  }
+
   public getCanFulfillIntentRequestRequest(
     intentName: string,
     slots?: any,

--- a/test/views.ts
+++ b/test/views.ts
@@ -1,6 +1,18 @@
 export const views = {
   "de-DE": {
     translation: {
+      APLKaraokeCommand: {
+        commands: [
+          {
+            align: "center",
+            componentId: "textComponent",
+            highlightMode: "line",
+            type: "SpeakItem",
+          },
+        ],
+        token: "SkillTemplateToken",
+        type: "Alexa.Presentation.APL.ExecuteCommands",
+      },
       APLTemplate: {
         datasources: {},
         document: {},
@@ -29,6 +41,18 @@ export const views = {
   },
   "en-US": {
     translation: {
+      APLKaraokeCommand: {
+        commands: [
+          {
+            align: "center",
+            componentId: "textComponent",
+            highlightMode: "line",
+            type: "SpeakItem",
+          },
+        ],
+        token: "SkillTemplateToken",
+        type: "Alexa.Presentation.APL.ExecuteCommands",
+      },
       APLTemplate: {
         datasources: {},
         document: {},

--- a/test/views.ts
+++ b/test/views.ts
@@ -1,6 +1,12 @@
 export const views = {
   "de-DE": {
     translation: {
+      APLTemplate: {
+        datasources: {},
+        document: {},
+        token: "SkillTemplateToken",
+        type: "Alexa.Presentation.APL.RenderDocument",
+      },
       Ask: "wie spät ist es?",
       ExitIntent: {
         Farewell: "Ok für weitere Infos besuchen {site} Website",
@@ -23,6 +29,12 @@ export const views = {
   },
   "en-US": {
     translation: {
+      APLTemplate: {
+        datasources: {},
+        document: {},
+        token: "SkillTemplateToken",
+        type: "Alexa.Presentation.APL.RenderDocument",
+      },
       AccountLinking: "Please Log in",
       Ask: {
         ask: "What time is it?",


### PR DESCRIPTION
This PR is basically to send the APL directives just like we send the RenderTemplate directives. We can pass the directive object directly into the APL directive key or we can use a variable set inside the views file.

Also added a event that fires when a user touch a TouchWrapper component from a APL Template.