### PR TITLE
Weird bug in the userId

### DIFF
--- a/src/platforms/dialogflow/DialogFlowEvent.ts
+++ b/src/platforms/dialogflow/DialogFlowEvent.ts
@@ -102,10 +102,10 @@ export class DialogFlowEvent extends VoxaEvent {
     this.source = _.get(originalDetectIntentRequest, "source") || "google";
 
     if (this.source === "google") {
-      if (_.get(storage, "voxa.userId")) {
-        userId = storage.voxa.userId;
-      } else if (conv.user.id) {
+      if (conv.user.id) {
         userId = conv.user.id;
+      } else if (_.get(storage, "voxa.userId")) {
+        userId = storage.voxa.userId;
       } else {
         userId = v1();
       }


### PR DESCRIPTION
For some reason the stored userId in userStorage sometimes differs from
the userId that comes in the request, that means related functionality
like sending notifications wouldn't work

This makes so we always use the userId from the request if present