### PR TITLE
Prioritize controllers with an intents array for the same state

### DIFF
--- a/src/StateMachine/StateMachine.ts
+++ b/src/StateMachine/StateMachine.ts
@@ -254,8 +254,8 @@ export class StateMachine {
       return states[0];
     }
 
-    // If the code reaches this points that means the `states` array contains
-    // one state without an intents array filter and
+    // If the code reaches this points that means the `states` array may contains
+    // one state without an intents array filter and/or
     // one or more states with an intents array that contains the intent name.
     // The state with an intents array is more important than the one with no intents array,
     // so let's return the first state that contains the intent name in its intents array.

--- a/src/StateMachine/StateMachine.ts
+++ b/src/StateMachine/StateMachine.ts
@@ -250,6 +250,20 @@ export class StateMachine {
       throw new UnknownState(currentStateName);
     }
 
-    return states[0];
+    if (states.length === 1) {
+      return states[0];
+    }
+
+    // If the code reaches this points that means the `states` array contains
+    // one state without an intents array filter and
+    // one or more states with an intents array that contains the intent name.
+    // The state with an intents array is more important than the one with no intents array,
+    // so let's return the first state that contains the intent name in its intents array.
+
+    return (
+      states.find(
+        (s: State) => s.intents.length && s.intents.includes(intentName),
+      ) || states[0] // Default value since by the method definition we need to return a `State` object
+    );
   }
 }


### PR DESCRIPTION
This PR tackles the problem described on #238. Please give it a read and let me know what you think.

The order of how we structure our code still matters in this change, but a controller with an intent filter has more priority over one that don't for the same state no matter the order of the controllers.

So if I have:

```
voxaApp.onState("myExampleState", { ... });
voxaApp.onState("myExampleState", { ... }, "YesIntent");
```

And the user triggers a `YesIntent`, the controller with the `YesIntent` filter is the one being executed.