### PR TITLE
Set not required play audio params in the interface

### DIFF
--- a/src/platforms/alexa/directives.ts
+++ b/src/platforms/alexa/directives.ts
@@ -457,9 +457,9 @@ export class AccountLinkingCard implements IDirective {
 export interface IAlexaPlayAudioDataOptions {
   url: string;
   token: string;
-  offsetInMilliseconds: number;
-  behavior: interfaces.audioplayer.PlayBehavior;
-  metadata: interfaces.audioplayer.AudioItemMetadata;
+  offsetInMilliseconds?: number;
+  behavior?: interfaces.audioplayer.PlayBehavior;
+  metadata?: interfaces.audioplayer.AudioItemMetadata;
 }
 
 export class PlayAudio extends MultimediaAlexaDirective implements IDirective {

--- a/test/alexa/directives.spec.ts
+++ b/test/alexa/directives.spec.ts
@@ -610,6 +610,32 @@ describe("Alexa directives", () => {
       ]);
     });
 
+    it("should render a PlayAudio directive with just the token and url", async () => {
+      app.onIntent("YesIntent", {
+        alexaPlayAudio: {
+          token: "token",
+          url: "url",
+        },
+        to: "die",
+      });
+
+      const reply = await alexaSkill.execute(event);
+      expect(reply.response.directives).to.deep.equal([
+        {
+          audioItem: {
+            metadata: {},
+            stream: {
+              offsetInMilliseconds: 0,
+              token: "token",
+              url: "url",
+            },
+          },
+          playBehavior: "REPLACE_ALL",
+          type: "AudioPlayer.Play",
+        },
+      ]);
+    });
+
     it("should throw an error when trying to add both a video and audio directive", async () => {
       app.onIntent("YesIntent", () => {
         const response = {


### PR DESCRIPTION
The `offsetInMilliseconds`, `behavior` and `metadata` params should be optionals in the interface definition