### PR TITLE
Prioritize controllers with an intents array for the same state

### DIFF
--- a/docs/voxa-app.rst
+++ b/docs/voxa-app.rst
@@ -98,9 +98,9 @@ Voxa Application
       return { tell: 'GoodbyeResponse', to: 'die' };
     });
 
-  If the state machine goes to the `ProcessUserRequest`, the code that will run always will be the first one, so the user will always hear the `ThankYouResponse`.
+  If the state machine goes to the `ProcessUserRequest`, the code running will always be the first one, so the user will always hear the `ThankYouResponse`.
 
-  The only scenario where this is overrided is when you have more than one for the same state, and one of them has one or more intents defined. If the user triggers the intent that's inside the list of intents of one controller Voxa will give it priority. For example, take this code:
+  The only scenario where this is overwritten is when you have more than one handler for the same state, and one of them has one or more intents defined. If the user triggers the intent that's inside the list of one-controller intents, Voxa will give it priority. For example, take this code:
 
   .. code-block:: javascript
 
@@ -118,7 +118,7 @@ Voxa Application
       to: "TransactionCancelled"
     }, ["NoIntent", "CancelIntent"]);
 
-  If the user triggers the `NoIntent`, and the state machine goes to the `agreed?` state, the user will listen the `TransactionCancelled` response, it doesn't matter if the controller is placed above or below a controller without defined intents, the priority will go to the controller with the defined intent.
+  If the user triggers the `NoIntent`, and the state machine goes to the `agreed?` state, the user will listen to the `TransactionCancelled` response, it doesn't matter if the controller is placed above or below a controller without defined intents, the priority will go to the controller with the defined intent.
 
 .. js:method:: VoxaApp.onIntent(intentName, handler)
 

--- a/docs/voxa-app.rst
+++ b/docs/voxa-app.rst
@@ -47,7 +47,7 @@ Voxa Application
       return { tell: 'LaunchIntent.OpenResponse', to: 'die' };
     });
 
-  Also you can use a shorthand version to define a state. This is very useful when having a state that only returns a :ref:`transition <transition>`
+  Also you can use a shorthand version to define a controller. This is very useful when having a controller that only returns a :ref:`transition <transition>`
 
   .. code-block:: javascript
 
@@ -59,7 +59,7 @@ Voxa Application
       }
     );
 
-  You can also set the intent that the state will handle. If set, any other triggered intent will not enter into the state.
+  You can also set the intent that the controller will handle. If set, any other triggered intent will not enter into the controller.
 
   .. code-block:: javascript
 
@@ -83,7 +83,7 @@ Voxa Application
       flow: "yield"
     });
 
-  **The order on how you structure your states matter in Voxa**
+  **The order on how you declare your controllers matter in Voxa**
 
   You can set multiple :ref:`controllers <controllers>` for a single state, so how do you know which code will be executed? The first one that Voxa finds. Take this example:
 
@@ -100,7 +100,7 @@ Voxa Application
 
   If the state machine goes to the `ProcessUserRequest`, the code that will run always will be the first one, so the user will always hear the `ThankYouResponse`.
 
-  The only scenario where this is overrided is when you have two controllers for the same state, and one of them has one or more intents defined to handle. If the user triggers the intent that's inside the defined intents Voxa will give priority to the state with intents. For example, take this code:
+  The only scenario where this is overrided is when you have more than one for the same state, and one of them has one or more intents defined. If the user triggers the intent that's inside the list of intents of one controller Voxa will give it priority. For example, take this code:
 
   .. code-block:: javascript
 

--- a/docs/voxa-app.rst
+++ b/docs/voxa-app.rst
@@ -63,27 +63,29 @@ Voxa Application
 
   .. code-block:: javascript
 
-    voxaApp.onState('MyState',
-      {
-        flow: 'yield'
-        reply: 'OpenResponse',
-        to: 'nextState'
-      },
-      "YesIntent"
-    );
+    voxaApp.onState("agreed?", {
+      to: "PurchaseAccepted"
+    }, "YesIntent");
 
-    voxaApp.onState('MyState',
-      {
-        flow: 'yield'
-        reply: 'OpenResponse',
-        to: 'nextState'
-      },
-      ["StopIntent", "CancelIntent"]
-    );
+    voxaApp.onState("agreed?", {
+      to: "TransactionCancelled"
+    }, ["NoIntent", "CancelIntent"]);
+
+    voxaApp.onState("agreed?", {
+      to: "agreed?",
+      reply: "Help.ArticleExplanation",
+      flow: "yield"
+    }, "HelpIntent");
+
+    voxaApp.onState("agreed?", {
+      to: "agreed?",
+      reply: "UnknownInput",
+      flow: "yield"
+    });
 
   **The order on how you structure your states matter in Voxa**
 
-  In theory you can set two states with the same name, so how do you know which code will be executed? The first one that Voxa finds. Take this example:
+  You can set multiple :ref:`controllers <controllers>` for a single state, so how do you know which code will be executed? The first one that Voxa finds. Take this example:
 
   .. code-block:: javascript
 
@@ -98,20 +100,25 @@ Voxa Application
 
   If the state machine goes to the `ProcessUserRequest`, the code that will run always will be the first one, so the user will always hear the `ThankYouResponse`.
 
-  The only scenario where this is overrided is when you have two states with the same name and one of them has one or more intents defined to handle. If the user triggers the intent inside the defined intents, Voxa will give priority to the state with intents. For example, take this code:
+  The only scenario where this is overrided is when you have two controllers for the same state, and one of them has one or more intents defined to handle. If the user triggers the intent that's inside the defined intents Voxa will give priority to the state with intents. For example, take this code:
 
   .. code-block:: javascript
 
-    voxaApp.onState('ProcessUserRequest', (voxaEvent) => {
-      // Some code
-      return { tell: 'ThankYouResponse', to: 'die' };
-    });
-    voxaApp.onState('ProcessUserRequest', (voxaEvent) => {
-      // Some other code
-      return { tell: 'GoodbyeResponse', to: 'die' };
+    voxaApp.onState("agreed?", {
+      to: "PurchaseAccepted"
     }, "YesIntent");
 
-  If the user triggers a `YesIntent`, and the state machine goes to the `ProcessUserRequest` state, the user will listen the `GoodbyeResponse`, it doesn't matter if the code is above or below the other state.
+    voxaApp.onState("agreed?", {
+      to: "agreed?",
+      reply: "UnknownInput",
+      flow: "yield"
+    });
+
+    voxaApp.onState("agreed?", {
+      to: "TransactionCancelled"
+    }, ["NoIntent", "CancelIntent"]);
+
+  If the user triggers the `NoIntent`, and the state machine goes to the `agreed?` state, the user will listen the `TransactionCancelled` response, it doesn't matter if the controller is placed above or below a controller without defined intents, the priority will go to the controller with the defined intent.
 
 .. js:method:: VoxaApp.onIntent(intentName, handler)
 

--- a/docs/voxa-app.rst
+++ b/docs/voxa-app.rst
@@ -33,6 +33,7 @@ Voxa Application
 
   :param string stateName: The name of the state
   :param function/object handler: The controller to handle the state
+  :param string/array intent: The intents that this state will handle
   :returns: An object or a promise that resolves to an object that specifies a transition to another state and/or a view to render
 
   .. code-block:: javascript
@@ -45,6 +46,72 @@ Voxa Application
     app.onState('launch', (voxaEvent) => {
       return { tell: 'LaunchIntent.OpenResponse', to: 'die' };
     });
+
+  Also you can use a shorthand version to define a state. This is very useful when having a state that only returns a :ref:`transition <transition>`
+
+  .. code-block:: javascript
+
+    voxaApp.onState('launch',
+      {
+        flow: 'yield'
+        reply: 'LaunchIntent.OpenResponse',
+        to: 'nextState'
+      }
+    );
+
+  You can also set the intent that the state will handle. If set, any other triggered intent will not enter into the state.
+
+  .. code-block:: javascript
+
+    voxaApp.onState('MyState',
+      {
+        flow: 'yield'
+        reply: 'OpenResponse',
+        to: 'nextState'
+      },
+      "YesIntent"
+    );
+
+    voxaApp.onState('MyState',
+      {
+        flow: 'yield'
+        reply: 'OpenResponse',
+        to: 'nextState'
+      },
+      ["StopIntent", "CancelIntent"]
+    );
+
+  **The order on how you structure your states matter in Voxa**
+
+  In theory you can set two states with the same name, so how do you know which code will be executed? The first one that Voxa finds. Take this example:
+
+  .. code-block:: javascript
+
+    voxaApp.onState('ProcessUserRequest', (voxaEvent) => {
+      // Some code
+      return { tell: 'ThankYouResponse', to: 'die' };
+    });
+    voxaApp.onState('ProcessUserRequest', (voxaEvent) => {
+      // Some other code
+      return { tell: 'GoodbyeResponse', to: 'die' };
+    });
+
+  If the state machine goes to the `ProcessUserRequest`, the code that will run always will be the first one, so the user will always hear the `ThankYouResponse`.
+
+  The only scenario where this is overrided is when you have two states with the same name and one of them has one or more intents defined to handle. If the user triggers the intent inside the defined intents, Voxa will give priority to the state with intents. For example, take this code:
+
+  .. code-block:: javascript
+
+    voxaApp.onState('ProcessUserRequest', (voxaEvent) => {
+      // Some code
+      return { tell: 'ThankYouResponse', to: 'die' };
+    });
+    voxaApp.onState('ProcessUserRequest', (voxaEvent) => {
+      // Some other code
+      return { tell: 'GoodbyeResponse', to: 'die' };
+    }, "YesIntent");
+
+  If the user triggers a `YesIntent`, and the state machine goes to the `ProcessUserRequest` state, the user will listen the `GoodbyeResponse`, it doesn't matter if the code is above or below the other state.
 
 .. js:method:: VoxaApp.onIntent(intentName, handler)
 

--- a/src/StateMachine/StateMachine.ts
+++ b/src/StateMachine/StateMachine.ts
@@ -254,11 +254,11 @@ export class StateMachine {
       return states[0];
     }
 
-    // If the code reaches this points that means the `states` array may contains
+    // If the code reaches this points that means the `states` array may contain
     // one state without an intents array filter and/or
-    // one or more states with an intents array that contains the intent name.
-    // The state with an intents array is more important than the one with no intents array,
-    // so let's return the first state that contains the intent name in its intents array.
+    // one or more controllers with an intents array that contains the intent name.
+    // The controller with an intents array is given more priority than the one with no intents array,
+    // so let's return the first controller that contains the intent name in its intents array.
 
     return (
       states.find(

--- a/src/StateMachine/StateMachine.ts
+++ b/src/StateMachine/StateMachine.ts
@@ -254,8 +254,8 @@ export class StateMachine {
       return states[0];
     }
 
-    // If the code reaches this points that means the `states` array contains
-    // one state without an intents array filter and
+    // If the code reaches this points that means the `states` array may contains
+    // one state without an intents array filter and/or
     // one or more states with an intents array that contains the intent name.
     // The state with an intents array is more important than the one with no intents array,
     // so let's return the first state that contains the intent name in its intents array.

--- a/src/StateMachine/StateMachine.ts
+++ b/src/StateMachine/StateMachine.ts
@@ -250,6 +250,20 @@ export class StateMachine {
       throw new UnknownState(currentStateName);
     }
 
-    return states[0];
+    if (states.length === 1) {
+      return states[0];
+    }
+
+    // If the code reaches this points that means the `states` array contains
+    // one state without an intents array filter and
+    // one or more states with an intents array that contains the intent name.
+    // The state with an intents array is more important than the one with no intents array,
+    // so let's return the first state that contains the intent name in its intents array.
+
+    return (
+      states.find(
+        (s: State) => s.intents.length && s.intents.includes(intentName),
+      ) || states[0] // Default value since by the method definition we need to return a `State` object
+    );
   }
 }

--- a/src/StateMachine/StateMachine.ts
+++ b/src/StateMachine/StateMachine.ts
@@ -254,16 +254,16 @@ export class StateMachine {
       return states[0];
     }
 
-    // If the code reaches this points that means the `states` array may contain
+    // If the code reaches this point, that means the `states` array may contain
     // one state without an intents array filter and/or
     // one or more controllers with an intents array that contains the intent name.
     // The controller with an intents array is given more priority than the one with no intents array,
-    // so let's return the first controller that contains the intent name in its intents array.
+    // so the first controller that contains the intent name in its intents array is returned.
 
     return (
       states.find(
         (s: State) => s.intents.length && s.intents.includes(intentName),
-      ) || states[0] // Default value since by the method definition we need to return a `State` object
+      ) || states[0] // If no state with name is found, the first state is returned by default as an State object is always needed
     );
   }
 }


### PR DESCRIPTION
fix #238

This PR tackles the problem described on #238. Please give it a read and let me know what you think.

The order of how we structure our code still matters in this change, but a controller with an intent filter has more priority over one that don't for the same state no matter the order of the controllers.

So if I have:

```
voxaApp.onState("myExampleState", { ... });
voxaApp.onState("myExampleState", { ... }, "YesIntent");
```

And the user triggers a `YesIntent`, the controller with the `YesIntent` filter is the one being executed.