### PR TITLE
Set unused params as optionals in directives method

### DIFF
--- a/docs/voxa-app.rst
+++ b/docs/voxa-app.rst
@@ -269,15 +269,16 @@ Handle events from the `AudioPlayer interface <https://developer.amazon.com/publ
   .. code-block:: javascript
 
     app['onAudioPlayer.PlaybackNearlyFinished']((voxaEvent, reply) => {
-      const directives = {
-        type: 'AudioPlayer.Play',
-        playBehavior: 'REPLACE_ENQUEUED',
-        token: "",
-        url: 'https://www.dl-sounds.com/wp-content/uploads/edd/2016/09/Classical-Bed3-preview.mp3',
+      const playAudio = new PlayAudio({
+        behavior: "REPLACE_ALL",
         offsetInMilliseconds: 0,
-      };
+        token: "",
+        url: 'https://www.dl-sounds.com/wp-content/uploads/edd/2016/09/Classical-Bed3-preview.mp3'
+      });
 
-      return reply.append({ directives });
+      playAudio.writeToReply(reply);
+
+      return reply;
     });
 
 

--- a/src/platforms/alexa/directives.ts
+++ b/src/platforms/alexa/directives.ts
@@ -87,7 +87,7 @@ export class HomeCard implements IDirective {
   public async writeToReply(
     reply: IVoxaReply,
     event: IVoxaEvent,
-    transition: ITransition,
+    transition?: ITransition,
   ): Promise<void> {
     if (reply.hasDirective("card")) {
       throw new Error("At most one card can be specified in a response");
@@ -118,7 +118,7 @@ export class Hint implements IDirective {
   public async writeToReply(
     reply: IVoxaReply,
     event: IVoxaEvent,
-    transition: ITransition,
+    transition?: ITransition,
   ): Promise<void> {
     if (reply.hasDirective("Hint")) {
       throw new Error(
@@ -156,7 +156,7 @@ export class DialogDelegate extends AlexaDirective implements IDirective {
   public async writeToReply(
     reply: IVoxaReply,
     event: IVoxaEvent,
-    transition: ITransition,
+    transition?: ITransition,
   ): Promise<void> {
     this.buildDirective(event);
     this.buildSlots(event);
@@ -318,7 +318,7 @@ export class RenderTemplate extends AlexaDirective implements IDirective {
   public async writeToReply(
     reply: IVoxaReply,
     event: IVoxaEvent,
-    transition: ITransition,
+    transition?: ITransition,
   ): Promise<void> {
     this.validateReply(reply);
 
@@ -364,7 +364,7 @@ export class APLTemplate extends AlexaDirective implements IDirective {
   public async writeToReply(
     reply: IVoxaReply,
     event: IVoxaEvent,
-    transition: ITransition,
+    transition?: ITransition,
   ): Promise<void> {
     this.validateReply(reply);
 
@@ -412,7 +412,7 @@ export class APLCommand extends AlexaDirective implements IDirective {
   public async writeToReply(
     reply: IVoxaReply,
     event: IVoxaEvent,
-    transition: ITransition,
+    transition?: ITransition,
   ): Promise<void> {
     this.validateReply(reply);
 
@@ -442,8 +442,8 @@ export class AccountLinkingCard implements IDirective {
 
   public async writeToReply(
     reply: IVoxaReply,
-    event: IVoxaEvent,
-    transition: ITransition,
+    event?: IVoxaEvent,
+    transition?: ITransition,
   ): Promise<void> {
     if (reply.hasDirective("card")) {
       throw new Error("At most one card can be specified in a response");
@@ -476,8 +476,8 @@ export class PlayAudio extends MultimediaAlexaDirective implements IDirective {
 
   public async writeToReply(
     reply: IVoxaReply,
-    event: IVoxaEvent,
-    transition: ITransition,
+    event?: IVoxaEvent,
+    transition?: ITransition,
   ): Promise<void> {
     this.validateReply(reply);
 
@@ -508,8 +508,8 @@ export class StopAudio extends AlexaDirective implements IDirective {
 
   public async writeToReply(
     reply: IVoxaReply,
-    event: IVoxaEvent,
-    transition: ITransition,
+    event?: IVoxaEvent,
+    transition?: ITransition,
   ): Promise<void> {
     this.addDirective(reply);
   }
@@ -530,8 +530,8 @@ export class GadgetControllerLightDirective extends AlexaDirective
 
   public async writeToReply(
     reply: IVoxaReply,
-    event: IVoxaEvent,
-    transition: ITransition,
+    event?: IVoxaEvent,
+    transition?: ITransition,
   ): Promise<void> {
     this.addDirective(reply);
   }
@@ -550,8 +550,8 @@ export class GameEngineStartInputHandler extends AlexaDirective
 
   public async writeToReply(
     reply: IVoxaReply,
-    event: IVoxaEvent,
-    transition: ITransition,
+    event?: IVoxaEvent,
+    transition?: ITransition,
   ): Promise<void> {
     this.addDirective(reply);
 
@@ -571,8 +571,8 @@ export class GameEngineStopInputHandler extends AlexaDirective
 
   public async writeToReply(
     reply: IVoxaReply,
-    event: IVoxaEvent,
-    transition: ITransition,
+    event?: IVoxaEvent,
+    transition?: ITransition,
   ): Promise<void> {
     this.directive = {
       originatingRequestId: this.originatingRequestId,
@@ -607,8 +607,8 @@ export class ConnectionsSendRequest extends AlexaDirective
 
   public async writeToReply(
     reply: IVoxaReply,
-    event: IVoxaEvent,
-    transition: ITransition,
+    event?: IVoxaEvent,
+    transition?: ITransition,
   ): Promise<void> {
     if (this.name) {
       this.directive = {
@@ -642,7 +642,7 @@ export class VideoAppLaunch extends MultimediaAlexaDirective {
   public async writeToReply(
     reply: IVoxaReply,
     event: IVoxaEvent,
-    transition: ITransition,
+    transition?: ITransition,
   ): Promise<void> {
     this.validateReply(reply);
 

--- a/src/platforms/botframework/directives.ts
+++ b/src/platforms/botframework/directives.ts
@@ -39,8 +39,8 @@ export class SigninCard implements IDirective {
 
   public async writeToReply(
     reply: IVoxaReply,
-    event: IVoxaEvent,
-    transition: ITransition,
+    event?: IVoxaEvent,
+    transition?: ITransition,
   ) {
     const card = new SigninCardType();
     card.button(this.signInOptions.buttonTitle, this.signInOptions.url);
@@ -61,7 +61,7 @@ export class HeroCard extends RenderDirective<string | HeroCardType>
   public async writeToReply(
     reply: IVoxaReply,
     event: IVoxaEvent,
-    transition: ITransition,
+    transition?: ITransition,
   ) {
     const card = await this.renderOptions(event);
     const attachments = (reply as BotFrameworkReply).attachments || [];
@@ -80,7 +80,7 @@ export class SuggestedActions
   public async writeToReply(
     reply: IVoxaReply,
     event: IVoxaEvent,
-    transition: ITransition,
+    transition?: ITransition,
   ) {
     const suggestedActionsType = await this.renderOptions(event);
     const suggestedActions: ISuggestedActions = suggestedActionsType.toSuggestedActions
@@ -134,8 +134,8 @@ function createMessageDirective<IOptions>(
     constructor(public options: IOptions) {}
     public async writeToReply(
       reply: IVoxaReply,
-      event: IVoxaEvent,
-      transition: ITransition,
+      event?: IVoxaEvent,
+      transition?: ITransition,
     ) {
       (reply as any)[messageKey] = this.options;
     }

--- a/src/platforms/dialogflow/facebook/directives.ts
+++ b/src/platforms/dialogflow/facebook/directives.ts
@@ -23,7 +23,7 @@ function createQuickReplyDirective(
     public async writeToReply(
       reply: IVoxaReply,
       event: IVoxaEvent,
-      transition: ITransition,
+      transition?: ITransition,
     ): Promise<void> {
       const dialogflowReply = reply as FacebookReply;
       const quickReplies: any[] = [];
@@ -84,7 +84,7 @@ function createGenericTemplateDirective(
     public async writeToReply(
       reply: IVoxaReply,
       event: IVoxaEvent,
-      transition: ITransition,
+      transition?: ITransition,
     ): Promise<void> {
       const dialogflowReply = (reply as FacebookReply);
       let configElements: IFacebookElementTemplate[]|undefined;
@@ -191,7 +191,7 @@ export class FacebookAccountLink implements IDirective {
   public async writeToReply(
     reply: IVoxaReply,
     event: IVoxaEvent,
-    transition: ITransition,
+    transition?: ITransition,
   ): Promise<void> {
     const dialogflowReply = reply as FacebookReply;
 
@@ -243,7 +243,7 @@ export class FacebookAccountUnlink implements IDirective {
   public async writeToReply(
     reply: IVoxaReply,
     event: IVoxaEvent,
-    transition: ITransition,
+    transition?: ITransition,
   ): Promise<void> {
     const dialogflowReply = reply as FacebookReply;
 
@@ -280,7 +280,7 @@ export class FacebookSuggestionChips implements IDirective {
   public async writeToReply(
     reply: IVoxaReply,
     event: IVoxaEvent,
-    transition: ITransition,
+    transition?: ITransition,
   ): Promise<void> {
     const suggestionChips: any[] = await this.getSuggestionChips(event);
     const dialogflowReply = reply as FacebookReply;

--- a/src/platforms/dialogflow/google/directives.ts
+++ b/src/platforms/dialogflow/google/directives.ts
@@ -89,7 +89,7 @@ function createSystemIntentDirective<IOptions>(
     public async writeToReply(
       reply: IVoxaReply,
       event: IVoxaEvent,
-      transition: ITransition,
+      transition?: ITransition,
     ): Promise<void> {
       if (!this.hasRequiredCapability(event)) {
         return;
@@ -122,7 +122,7 @@ function createRichResponseDirective<IOptions>(
     public async writeToReply(
       reply: IVoxaReply,
       event: IVoxaEvent,
-      transition: ITransition,
+      transition?: ITransition,
     ): Promise<void> {
       if (!this.hasRequiredCapability(event)) {
         return;
@@ -262,7 +262,7 @@ export class Suggestions implements IDirective {
   public async writeToReply(
     reply: IVoxaReply,
     event: IVoxaEvent,
-    transition: ITransition,
+    transition?: ITransition,
   ): Promise<void> {
     let options = this.suggestions;
 
@@ -292,7 +292,7 @@ export class Context implements IDirective {
   public async writeToReply(
     reply: IVoxaReply,
     event: IVoxaEvent,
-    transition: ITransition,
+    transition?: ITransition,
   ): Promise<void> {
     const conv: DialogflowConversation = (event as DialogflowEvent).dialogflow
       .conv;


### PR DESCRIPTION
Fixes #247 

So I went through all existing directives and set unused params as optional, not for every directive but for the ones not using the params.

So, using the example in issue #247, I can now just use it in Typescript as: `  playAudio.writeToReply(reply);`