### PR TITLE
Change Voxa Author

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "echo",
     "amazon"
   ],
-  "author": "Rain Agency <npm@rain.agency> (http://rain.agency)",
+  "author": "Voxa <voxa@nicasource.com> (https://voxa.ai)",
   "engines": {
     "node": ">=8.10"
   },


### PR DESCRIPTION
I've created a new NPM organization that is generic to use Voxa.  We'll add additional community maintainers to that organization.   But we will change the author line here.   Does anything else need to be done in order to change the displayed author in NPM to be Voxa?  