### PR TITLE
Pinning botbuilder to 3.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: required
 node_js:
-  - "8.10"
   - "10"
   - "12"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # VOXA Changelog
 
+## 3.3.3 (2020-04-30)
+
+#### Bug Fix
+
+- Fixes error `Cannot find module 'skills-validator' brought by new botbuilder package version.`
+
 ## 3.3.2 (2020-02-05)
 
 #### Enhancement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Bug Fix
 
-- Fixes error `Cannot find module 'skills-validator' brought by new botbuilder package version.`
+- Fixes error to find module 'skills-validator' brought by new botbuilder package version.
 
 ## 3.3.2 (2020-02-05)
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ask-sdk-model": "^1.25.1",
     "azure-functions-ts-essentials": "^1.3.2",
     "bluebird": "^3.5.5",
-    "botbuilder": "^3.16",
+    "botbuilder": "3.16",
     "fast-xml-parser": "^3.12.16",
     "google-auth-library": "1.6.1",
     "googleapis": "^40.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voxa",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "A fsm (state machine) framework for Alexa, Dialogflow, Facebook Messenger and Botframework apps using Node.js",
   "main": "./lib/src/index.js",
   "types": "./lib/src/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -633,9 +633,10 @@ bluebird@^3.5.0, bluebird@^3.5.5:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
 
-botbuilder@^3.16:
+botbuilder@3.16:
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/botbuilder/-/botbuilder-3.16.0.tgz#700ea391892c626fa1f922688d2c742b0684f503"
+  integrity sha512-Gf51aNfvBuAxKSXQ+1SV/P1lzuRMyMyIqvjUUSqpjbtW6lFkPHhCmJIM0Dgxbflq78EXXisIYZQgAqsUNYeVQQ==
   dependencies:
     "@types/async" "^2.0.48"
     "@types/express" "^4.11.1"
@@ -3676,10 +3677,6 @@ tough-cookie@~2.4.3:
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
-
-tree-kill@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.1.tgz#5398f374e2f292b9dcc7b2e71e30a5c3bb6c743a"
 
 trim-right@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Fixing Error: Cannot find module 'skills-validator' brought by new botbuilder package version.